### PR TITLE
Priv Unit Fixes

### DIFF
--- a/example.yml
+++ b/example.yml
@@ -19,6 +19,9 @@ microarch_params:
   # Sparisty Optimizations
   sparce_enabled : "disabled"
 
+  # Halt
+  infinite_loop_halts: "true"
+
 # RISC-MGMT Extension Configuration
 risc_mgmt_params:
   standard_extensions:

--- a/scripts/config_core.py
+++ b/scripts/config_core.py
@@ -46,7 +46,9 @@ UARCH_PARAMS = \
     'bus_endianness' : ['big', 'little'],
     'bus_interface_type' : ['ahb_if', 'generic_bus_if'],
     # Sparisty Optimizations
-    'sparce_enabled' : [ 'enabled', 'disabled' ]
+    'sparce_enabled' : [ 'enabled', 'disabled' ],
+    # Halt Enable -- Good for testing, not for tapeout
+    'infinite_loop_halts' : ['true', 'false']
   }
 
 RISC_MGMT_PARAMS = \

--- a/source_code/pipelines/tspp/tspp_fetch_stage.sv
+++ b/source_code/pipelines/tspp/tspp_fetch_stage.sv
@@ -39,8 +39,8 @@ module tspp_fetch_stage (
 );
   import rv32i_types_pkg::*;
 
-  parameter RESET_PC = 32'h200;
-  //parameter RESET_PC = 32'h80000000;
+  //parameter RESET_PC = 32'h200;
+  parameter RESET_PC = 32'h80000000;
 
   word_t  pc, pc4, npc, instr;
 

--- a/source_code/pipelines/tspp/tspp_fetch_stage.sv
+++ b/source_code/pipelines/tspp/tspp_fetch_stage.sv
@@ -39,8 +39,8 @@ module tspp_fetch_stage (
 );
   import rv32i_types_pkg::*;
 
-  //parameter RESET_PC = 32'h200;
-  parameter RESET_PC = 32'h80000000;
+  parameter RESET_PC = 32'h200;
+  //parameter RESET_PC = 32'h80000000;
 
   word_t  pc, pc4, npc, instr;
 

--- a/source_code/privs/priv_1_11/priv_1_11_control.sv
+++ b/source_code/privs/priv_1_11/priv_1_11_control.sv
@@ -189,6 +189,17 @@ module priv_1_11_control (
       interrupt_reg <= '0;			
   end 
 
+  /*
+   * Fix for MIE/MPIE issue. This used to be the same as 'interrupt_reg' above,
+   * but the above stays high for 2+ cycles (i.e. waiting for pipe_clear).
+   * This caused MPIE to update twice; the first update would set MPIE to 1,
+   * and the second would cause MPIE to return to 0. Then, after an MRET,
+   * MIE would not be restored since MPIE was lost. Additionally, shortening
+   * interrupt_reg was not an option since pipe_clear must be asserted for the
+   * PC to be inserted into the pipeline from the priv unit, so creating this
+   * extra register was the cleanest solution to ensuring MPIE updates exactly
+   * once.
+   */
   always_ff @(posedge CLK, negedge nRST) begin
     if(!nRST)
       update_mie <= '0;

--- a/source_code/standard_core/control_unit.sv
+++ b/source_code/standard_core/control_unit.sv
@@ -185,8 +185,15 @@ module control_unit
   end
 
   // HALT HACK. Just looking for j + 0x0 (infinite loop)
-  // TODO: FIX ME WHEN IMPLEMENTING INTERRUPTS
-  assign cu_if.halt = (cu_if.instr == 32'h0000006f);
+  // Halt required for unit testing, but not useful in tapeout context
+  // Due to presence of interrupts, infinite loops are valid
+  generate
+    if(INFINITE_LOOP_HALTS == "true") begin
+      assign cu_if.halt = (cu_if.instr == 32'h0000006f);
+    end else begin
+      assign cu_if.halt = '0;
+    end
+  endgenerate
   // Privilege Control Signals
   assign cu_if.fault_insn = '0;
  

--- a/source_code/standard_core/memory_controller.sv
+++ b/source_code/standard_core/memory_controller.sv
@@ -59,6 +59,20 @@ module memory_controller (
   end 
 
   /* State Transition Logic */ 
+  /*
+  * Note: After interrupts were integrated, receiving an interrupt forces IREN
+  * to go low. On an instruction request, the FSM assumed IREN high, and unconditionally
+  * proceeded to an instruction wait state (either INSTR_WAIT or INSTR_DATA_REQ). However,
+  * since IREN was low, the AHB master did not actually receive a request, and therefore the
+  * I-Bus would never see a "ready" condition; the AHB master would be locked in IDLE, and
+  * this FSM would be locked in the instruction wait state forever.
+  *
+  * To fix, I added logic to abort an instruction request if the IREN signal was low in
+  * the INSTR_REQ or DATA_INSTR_REQ state; this only happens on an interrupt, so simply aborting
+  * the transaction on the next transition should be safe since the pipeline will be flushed anyways;
+  * the instruction request in question should not be fetched since the next instruction should be from
+  * the interrupt handler after the new PC is inserted.
+  */
   always_comb 
   begin 
     case(current_state) 
@@ -71,7 +85,9 @@ module memory_controller (
           next_state = IDLE; 
       end 
 
-      INSTR_REQ: begin 
+      INSTR_REQ: begin
+        if(!i_gen_bus_if.ren) // Abort request, received an interrupt
+          next_state = IDLE;
         if(d_gen_bus_if.ren || d_gen_bus_if.wen) 
           next_state = INSTR_DATA_REQ;
         else 
@@ -92,8 +108,10 @@ module memory_controller (
           next_state = DATA_WAIT; 
       end
 
-      DATA_INSTR_REQ: begin 
-        if( out_gen_bus_if.busy == 1'b0 ) 
+      DATA_INSTR_REQ: begin
+        if(!i_gen_bus_if.ren && out_gen_bus_if.busy == 1'b0) // Abort request, received an interrupt
+          next_state = IDLE;
+        else if(out_gen_bus_if.busy == 1'b0) 
           next_state = INSTR_WAIT; 
         else 
           next_state = DATA_INSTR_REQ; 

--- a/source_code/standard_core/memory_controller.sv
+++ b/source_code/standard_core/memory_controller.sv
@@ -88,7 +88,7 @@ module memory_controller (
       INSTR_REQ: begin
         if(!i_gen_bus_if.ren) // Abort request, received an interrupt
           next_state = IDLE;
-        if(d_gen_bus_if.ren || d_gen_bus_if.wen) 
+        else if(d_gen_bus_if.ren || d_gen_bus_if.wen) 
           next_state = INSTR_DATA_REQ;
         else 
           next_state = INSTR_WAIT; 

--- a/sparce.yml
+++ b/sparce.yml
@@ -19,6 +19,9 @@ microarch_params:
   # Sparisty Optimizations
   sparce_enabled : "enabled"
 
+  # Halt
+  infinite_loop_halts : "true"
+
 # RISC-MGMT Extension Configuration
 risc_mgmt_params:
   standard_extensions:


### PR DESCRIPTION
Priv Unit: Fixed an issue where MEPC was able to update multiple times per interrupt, resulting in a situation where MRET would return to the beginning of the interrupt handler and looping forever.

Memory controller: Fixed an issue where interrupts could cause deadlock in the memory controller. This was due to interrupts disabling the IREN signal mid-transaction, which made the AHB master not register a transaction. The memory controller on the other hand would wait for an HREADY from the AHB master, which wouldn't ever come. To fix, I added the ability for the memory controller to abort a transaction if the IREN signal went low while waiting for a response.

config_core.py: Added an option to enable/disable the processor halt on infinite loop behavior now that interrupts have been added. This option should be enabled when doing ISA tests, but disabled for top-level integration/tapeouts.