### PR TITLE
updated memory_arbiter with latches to fix timing loops

### DIFF
--- a/source_code/caches/l2/l2_cache.sv
+++ b/source_code/caches/l2/l2_cache.sv
@@ -450,15 +450,14 @@ module l2_cache #(
                     if(proc_gen_bus_if.ren)begin
                         mem_gen_bus_if.ren      = 1'b1;
                         mem_gen_bus_if.addr     = proc_gen_bus_if.addr;
-                        proc_gen_bus_if.busy    = mem_gen_bus_if.busy; //TODO: CHECK, ADDED BY VERIFICATION
+                        proc_gen_bus_if.busy    = mem_gen_bus_if.busy;
                         proc_gen_bus_if.rdata   = mem_gen_bus_if.rdata;
                     end
                     else if(proc_gen_bus_if.wen)begin
                         mem_gen_bus_if.wen      = 1'b1;
                         mem_gen_bus_if.addr     = proc_gen_bus_if.addr;
-                        proc_gen_bus_if.busy    = mem_gen_bus_if.busy; //TODO: CHECK, ADDED BY VERIFICATION
+                        proc_gen_bus_if.busy    = mem_gen_bus_if.busy;
                         mem_gen_bus_if.wdata    = proc_gen_bus_if.wdata;
-
                     end 
                 end
                 else if ((proc_gen_bus_if.ren || proc_gen_bus_if.wen) && ~hit && ~cache[decoded_addr.set_bits].frames[ridx].dirty && ~pass_through) begin // FETCH

--- a/source_code/caches/memory_arbiter.sv
+++ b/source_code/caches/memory_arbiter.sv
@@ -5,116 +5,129 @@ module memory_arbiter (
     generic_bus_if.generic_bus icache_if, dcache_if,
     generic_bus_if.cpu mem_arb_if
 );
-    typedef enum {IDLE, IREQUEST, DREQUEST} state_t;
+    typedef enum logic[1:0] {IDLE, IREQUEST, DREQUEST} state_t;
     state_t state, next_state;
+
+	generic_bus_if next_icache_if_out();
+	generic_bus_if next_dcache_if_out();
+
+	generic_bus_if next_mem_if();
+
+	always_ff @(posedge CLK, negedge nRST) begin : OUTPUT_LOGIC_FF
+		if (!nRST) begin
+			icache_if.rdata		<= '0;
+			icache_if.busy 		<= '1;
+
+			dcache_if.rdata		<= '0;
+			dcache_if.busy 		<= '1;
+
+			mem_arb_if.ren 	  	<= '0;
+			mem_arb_if.wen 	  	<= '0;
+			mem_arb_if.addr   	<= '0;
+			mem_arb_if.wdata  	<= '0;
+			mem_arb_if.byte_en	<= '0;
+		end else begin
+			icache_if.rdata		<= next_icache_if_out.rdata;
+			icache_if.busy 		<= next_icache_if_out.busy;
+
+			dcache_if.rdata		<= next_dcache_if_out.rdata;
+			dcache_if.busy 		<= next_dcache_if_out.busy;
+
+			mem_arb_if.ren 	  	<= next_mem_if.ren;
+			mem_arb_if.wen 	  	<= next_mem_if.wen;
+			mem_arb_if.addr   	<= next_mem_if.addr;
+			mem_arb_if.wdata  	<= next_mem_if.wdata;
+			mem_arb_if.byte_en	<= next_mem_if.byte_en;
+		end
+	end
     
-    // Output logic
-    always_comb begin
-	icache_if.busy 	  = 1'b1;
-	dcache_if.busy 	  = 1'b1;
-	icache_if.rdata   = '0;
-	dcache_if.rdata   = '0;
-	mem_arb_if.ren 	  = 1'b0;
-	mem_arb_if.wen 	  = 1'b0;
-	mem_arb_if.addr   = '0;
-	mem_arb_if.wdata  = '0;
+    always_comb begin : NEXT_OUTPUT_LOGIC
+		next_mem_if.ren 	  		= '0;
+		next_mem_if.wen 	  		= '0;
+		next_mem_if.addr   			= '0;
+		next_mem_if.wdata  			= '0;
+		next_mem_if.byte_en			= '0;
 
-	casez(state)
-	    IDLE: begin
-		if(dcache_if.wen) begin
-		    mem_arb_if.wen    = 1'b1;
-		    mem_arb_if.addr   = dcache_if.addr;
-		    mem_arb_if.wdata  = dcache_if.wdata;
-		end // if (dcache_if.wen)
-		else if(dcache_if.ren) begin
-		    mem_arb_if.ren   = 1'b1;
-		    mem_arb_if.addr  = dcache_if.addr;
-		end
-		else if(icache_if.ren) begin
-		    mem_arb_if.ren   = 1'b1;
-		    mem_arb_if.addr  = icache_if.addr;
-		end
-		else if(icache_if.wen) begin
-		    mem_arb_if.wen    = 1'b1;
-		    mem_arb_if.addr   = icache_if.addr;
-		    mem_arb_if.wdata  = icache_if.wdata;
-		end // if (icache_if.wen)
-	    end // case: IDLE
-	    IREQUEST: begin
-		if(~mem_arb_if.busy && icache_if.wen) begin
-		    icache_if.busy  = 1'b0;
-		end
-		else if(~mem_arb_if.busy) begin
-		    icache_if.busy   = 1'b0;
-		    icache_if.rdata  = mem_arb_if.rdata;
-		end
+		next_icache_if_out.busy 	= '1;
+		next_icache_if_out.rdata   	= '0;
 
-		if(icache_if.wen) begin
-		    mem_arb_if.wen    = 1'b1;
-		    mem_arb_if.wdata  = icache_if.wdata;
-		end
+		next_dcache_if_out.busy		= '1;
+		next_dcache_if_out.rdata   	= '0;
+
+		case(state)
+			IDLE: begin
+				if(dcache_if.wen || dcache_if.ren) begin
+					next_mem_if.ren 	  		= dcache_if.ren;
+					next_mem_if.wen 	  		= dcache_if.wen;
+					next_mem_if.addr   			= dcache_if.addr;
+					next_mem_if.wdata  			= dcache_if.wdata;
+					next_mem_if.byte_en			= dcache_if.byte_en;
+					next_dcache_if_out.busy 	= mem_arb_if.busy;
+					next_dcache_if_out.rdata 	= mem_arb_if.rdata;
+				end
+				else if(icache_if.wen || icache_if.ren) begin
+					next_mem_if.ren 	  		= icache_if.ren;
+					next_mem_if.wen 	  		= icache_if.wen;
+					next_mem_if.addr   			= icache_if.addr;
+					next_mem_if.wdata  			= icache_if.wdata;
+					next_mem_if.byte_en			= icache_if.byte_en;
+					next_icache_if_out.busy 	= mem_arb_if.busy;
+					next_icache_if_out.rdata 	= mem_arb_if.rdata;
+				end 
+			end
+			IREQUEST: begin
+				next_mem_if.ren 	  		= icache_if.ren;
+				next_mem_if.wen 	  		= icache_if.wen;
+				next_mem_if.addr   			= icache_if.addr;
+				next_mem_if.wdata  			= icache_if.wdata;
+				next_mem_if.byte_en			= icache_if.byte_en;
+				next_icache_if_out.busy 	= mem_arb_if.busy;
+				next_icache_if_out.rdata 	= mem_arb_if.rdata;
+			end
+			DREQUEST: begin
+				next_mem_if.ren 	  		= dcache_if.ren;
+				next_mem_if.wen 	  		= dcache_if.wen;
+				next_mem_if.addr   			= dcache_if.addr;
+				next_mem_if.wdata  			= dcache_if.wdata;
+				next_mem_if.byte_en			= dcache_if.byte_en;
+				next_dcache_if_out.busy 	= mem_arb_if.busy;
+				next_dcache_if_out.rdata 	= mem_arb_if.rdata;
+			end 
+		endcase
+	end
+
+   	always_comb begin : NEXT_STATE_LOGIC
+       	next_state  = state;
+
+       	case(state)
+			IDLE: begin
+				if(dcache_if.wen || dcache_if.ren) begin
+					next_state  = DREQUEST;
+				end
+				else if(icache_if.wen || icache_if.ren) begin
+					next_state  = IREQUEST;
+				end
+			end
+			DREQUEST: begin
+				if(~next_mem_if.busy) begin // hopefully, busy will always be high until fetch, so no problem
+					next_state  = IDLE;
+				end
+			end
+			IREQUEST: begin
+				if(~next_mem_if.busy) begin
+					next_state  = IDLE;
+				end
+			end
+      	endcase
+   	end
+    
+   	always_ff @ (posedge CLK, negedge nRST) begin : STATE_FF
+       	if(~nRST) begin
+	   		state <= IDLE;
+       	end 
 		else begin
-		    mem_arb_if.ren  = 1'b1;
-		end // else: !if(icache_if.wen)
-
-		mem_arb_if.addr = icache_if.addr;
-	    end // case: IREQUEST
-	    DREQUEST: begin
-		if(~mem_arb_if.busy && dcache_if.wen) begin
-		    dcache_if.busy  = 1'b0;
-		end
-		else if(~mem_arb_if.busy) begin
-		    dcache_if.busy   = 1'b0;
-		    dcache_if.rdata  = mem_arb_if.rdata;
-		end
-
-		if(dcache_if.wen) begin
-		    mem_arb_if.wen    = 1'b1;
-		    mem_arb_if.wdata  = dcache_if.wdata;
-		end
-		else begin
-		    mem_arb_if.ren  = 1'b1;
-		end // else: !if(dcache_if.wen)
-
-		mem_arb_if.addr  = dcache_if.addr;
-	    end // case: DREQUEST
-	endcase // casez (state)
-    end // always_comb
-
-   // next state logic
-   always_comb begin
-       next_state  = state;
-
-       casez(state)
-	   IDLE: begin
-	       if(dcache_if.wen || dcache_if.ren) begin
-		   next_state  = DREQUEST;
-	       end
-	       else if(icache_if.wen || icache_if.ren) begin
-		   next_state  = IREQUEST;
-	       end
-	   end // case: IDLE
-	   DREQUEST: begin
-	       if(~mem_arb_if.busy) begin // hopefully, busy will always be high until fetch, so no problem
-		   next_state  = IDLE;
-	       end
-	   end // case: DREQUEST
-	   IREQUEST: begin
-	       if(~mem_arb_if.busy) begin
-		   next_state  = IDLE;
-	       end
-	   end // case: IREQUEST
-       endcase // casez (state)
-   end // always_comb
+	   		state <= next_state;
+       	end
+   	end
     
-   always_ff @ (posedge CLK, negedge nRST) begin
-       if(~nRST) begin
-	   state <= IDLE;
-       end
-       else begin
-	   state <= next_state;
-       end // else: !if(~nRST)
-   end // always_ff @
-    
-endmodule // memory_arbiter
-
+endmodule


### PR DESCRIPTION
I have fixed the timing loop by changing the memory arbiter from purely combinational to going through FF.  This will change the timing of the design but I don't see another way to fix this.  As @AedanFrazier found, the L1 and memory arbiter both try to drive the proc_gen_bus_if because the d_cache_if in the memory arbiter is just an alias for the same bus as the proc_gen_bus_if.  Please look over these changes and see if we can move forward with this design change so that I can begin to change the uvm tb to account for the timing differences now. 