### PR TITLE
Privileged Unit 1.12 CSR Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,8 @@ _vmake
 *.qtl
 *.qpg
 
+# ignore python bytecode files
+*.pyc
+__pycache__/
+
 open_files.sh

--- a/dev.yml
+++ b/dev.yml
@@ -1,0 +1,36 @@
+# ISA Configurations
+isa_params:  
+  xlen : 32
+
+# Microarchitectural Configurations
+microarch_params:
+  # Branch/Jump Configurations
+  br_predictor_type : "not_taken"
+  
+  # Cache configurations
+  cache_config  : "separate"
+  dcache_type   : "pass_through"
+  icache_type   : "pass_through"
+  
+  # Bus configurations
+  bus_endianness      : "big"
+  bus_interface_type  : "ahb_if"
+
+  # Sparisty Optimizations
+  sparce_enabled : "disabled"
+
+  # RV32C
+  rv32c_enabled : "enabled"
+  
+  # Halt
+  infinite_loop_halts : "false"
+
+  # base ISA 
+  base_isa: "RV32I"
+
+# RISC-MGMT Extension Configuration
+risc_mgmt_params:
+  standard_extensions:
+      - name: "rv32m"
+  nonstandard_extensions:
+

--- a/normal.yml
+++ b/normal.yml
@@ -14,13 +14,13 @@ microarch_params:
   
   # Bus configurations
   bus_endianness      : "big"
-  bus_interface_type  : "ahb_if"
+  bus_interface_type  : "generic_bus_if"
 
   # Sparisty Optimizations
   sparce_enabled : "disabled"
 
   # RV32C
-  rv32c_enabled : "enabled"
+  rv32c_enabled : "disabled"
   
   # Halt
   infinite_loop_halts : "true"
@@ -31,6 +31,5 @@ microarch_params:
 # RISC-MGMT Extension Configuration
 risc_mgmt_params:
   standard_extensions:
-      - name: "rv32m"
   nonstandard_extensions:
 

--- a/source_code/include/priv_1_12_internal_if.vh
+++ b/source_code/include/priv_1_12_internal_if.vh
@@ -1,0 +1,47 @@
+/*
+*   Copyright 2016 Purdue University
+*
+*   Licensed under the Apache License, Version 2.0 (the "License");
+*   you may not use this file except in compliance with the License.
+*   You may obtain a copy of the License at
+*
+*       http://www.apache.org/licenses/LICENSE-2.0
+*
+*   Unless required by applicable law or agreed to in writing, software
+*   distributed under the License is distributed on an "AS IS" BASIS,
+*   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*   See the License for the specific language governing permissions and
+*   limitations under the License.
+*
+*
+*   Filename:     priv_1_12_internal_if.vh
+*
+*   Created by:   Hadi Ahmed
+*   Email:        ahmed138@purdue.edu
+*   Date Created: 03/27/2022
+*   Description:  Interface for components within the privilege block v1.12
+*/
+
+`ifndef PRIV_1_12_INTERNAL_IF_VH
+`define PRIV_1_12_INTERNAL_IF_VH
+
+`include "component_selection_defines.vh"
+
+interface priv_1_12_internal_if;
+    import machine_mode_types_1_12_pkg::*;
+    import rv32i_types_pkg::*;
+
+    mcsr_addr_t csr_addr; // CSR address to read
+    priv_level_t curr_priv; // Current process privilege
+    logic csr_mod; // Is the CSR currently being modified?
+    logic invalid_csr; // Bad CSR address
+    word_t new_csr_val, old_csr_val; // new and old CSR values (atomically swapped)
+
+    modport csr (
+        input csr_addr, curr_priv, csr_mod, new_csr_val,
+        output old_csr_val, invalid_csr
+    );
+
+endinterface
+
+`endif  // PRIV_1_12_INTERNAL_IF_VH

--- a/source_code/include/priv_1_12_internal_if.vh
+++ b/source_code/include/priv_1_12_internal_if.vh
@@ -33,13 +33,13 @@ interface priv_1_12_internal_if;
 
     mcsr_addr_t csr_addr; // CSR address to read
     priv_level_t curr_priv; // Current process privilege
-    logic csr_mod; // Is the CSR currently being modified?
+    logic csr_write, csr_set, csr_clear; // Is the CSR currently being modified?
     logic invalid_csr; // Bad CSR address
     logic inst_ret; // signal when an instruction is retired
     word_t new_csr_val, old_csr_val; // new and old CSR values (atomically swapped)
 
     modport csr (
-        input csr_addr, curr_priv, csr_mod, new_csr_val, inst_ret,
+        input csr_addr, curr_priv, csr_write, csr_set, csr_clear, new_csr_val, inst_ret,
         output old_csr_val, invalid_csr
     );
 

--- a/source_code/include/priv_1_12_internal_if.vh
+++ b/source_code/include/priv_1_12_internal_if.vh
@@ -35,10 +35,11 @@ interface priv_1_12_internal_if;
     priv_level_t curr_priv; // Current process privilege
     logic csr_mod; // Is the CSR currently being modified?
     logic invalid_csr; // Bad CSR address
+    logic inst_ret; // signal when an instruction is retired
     word_t new_csr_val, old_csr_val; // new and old CSR values (atomically swapped)
 
     modport csr (
-        input csr_addr, curr_priv, csr_mod, new_csr_val,
+        input csr_addr, curr_priv, csr_mod, new_csr_val, inst_ret,
         output old_csr_val, invalid_csr
     );
 

--- a/source_code/include/prv_pipeline_if.vh
+++ b/source_code/include/prv_pipeline_if.vh
@@ -1,12 +1,12 @@
 /*
 *   Copyright 2016 Purdue University
-*   
+*
 *   Licensed under the Apache License, Version 2.0 (the "License");
 *   you may not use this file except in compliance with the License.
 *   You may obtain a copy of the License at
-*   
+*
 *       http://www.apache.org/licenses/LICENSE-2.0
-*   
+*
 *   Unless required by applicable law or agreed to in writing, software
 *   distributed under the License is distributed on an "AS IS" BASIS,
 *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,7 +20,7 @@
 *   Email:        jskubic@purdue.edu
 *   Date Created: 08/24/2016
 *   Description:  Interface connecting the priv block to the pipeline.
-*                 Contains connections between modules inside the priv block. 
+*                 Contains connections between modules inside the priv block.
 *                 TODO: These two functionalities should be split into two
 *                 separate interfaces.
 */
@@ -31,7 +31,7 @@
 `include "component_selection_defines.vh"
 
 interface prv_pipeline_if();
-  import machine_mode_types_1_11_pkg::*;
+  import machine_mode_types_1_12_pkg::*;
   import rv32i_types_pkg::*;
 
   // exception signals
@@ -49,21 +49,21 @@ interface prv_pipeline_if();
   // csr rw
   logic       swap, clr, set;
   logic       invalid_csr, valid_write;
-  csr_addr_t  addr;
+  mcsr_addr_t maddr;
   word_t      rdata, wdata;
 
   // performance signals
   logic wb_enable, instr;
 
-  // RISC-MGMT 
+  // RISC-MGMT
   logic ex_rmgmt;
   logic [$clog2(`NUM_EXTENSIONS)-1:0] ex_rmgmt_cause;
 
   modport hazard (
     input priv_pc, insert_pc, intr,
-    output pipe_clear, ret, epc, fault_insn, mal_insn, 
+    output pipe_clear, ret, epc, fault_insn, mal_insn,
             illegal_insn, fault_l, mal_l, fault_s, mal_s,
-            breakpoint, env_m, badaddr, wb_enable, 
+            breakpoint, env_m, badaddr, wb_enable,
             ex_rmgmt, ex_rmgmt_cause
   );
 

--- a/source_code/include/prv_pipeline_if.vh
+++ b/source_code/include/prv_pipeline_if.vh
@@ -68,7 +68,7 @@ interface prv_pipeline_if();
   );
 
   modport pipe (
-    output swap, clr, set, wdata, addr, valid_write, instr,
+    output swap, clr, set, wdata, maddr, valid_write, instr,
     input  rdata, invalid_csr
   );
 
@@ -77,7 +77,7 @@ interface prv_pipeline_if();
     input pipe_clear, ret, epc, fault_insn, mal_insn,
           illegal_insn, fault_l, mal_l, fault_s, mal_s,
           breakpoint, env_m, badaddr, swap, clr, set,
-          wdata, addr, valid_write, wb_enable, instr,
+          wdata, maddr, valid_write, wb_enable, instr,
           ex_rmgmt, ex_rmgmt_cause,
     output priv_pc, insert_pc, intr, rdata, invalid_csr
   );

--- a/source_code/packages/machine_mode_types_1_12_pkg.sv
+++ b/source_code/packages/machine_mode_types_1_12_pkg.sv
@@ -1,0 +1,430 @@
+/*
+*   Copyright 2016 Purdue University
+*
+*   Licensed under the Apache License, Version 2.0 (the "License");
+*   you may not use this file except in compliance with the License.
+*   You may obtain a copy of the License at
+*
+*       http://www.apache.org/licenses/LICENSE-2.0
+*
+*   Unless required by applicable law or agreed to in writing, software
+*   distributed under the License is distributed on an "AS IS" BASIS,
+*   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*   See the License for the specific language governing permissions and
+*   limitations under the License.
+*
+*
+*   Filename:     machine_mode_types_1_12_pkg.sv
+*
+*   Created by:   Hadi Ahmed
+*   Email:        ahmed138@purdue.edu
+*   Date Created: 03/08/2022
+*   Description:  Types needed to implement machine mode priv. isa 1.12
+*/
+
+`ifndef MACHINE_MODE_TYPES_1_12_PKG_SV
+`define MACHINE_MODE_TYPES_1_12_PKG_SV
+
+package machine_mode_types_1_12_pkg;
+
+  /* Machine Mode Addresses */
+  typedef enum logic [11:0] {
+    /* Machine Information Registers */
+    MVENDORID_ADDR  = 12'hF11,
+    MARCHID_ADDR    = 12'hF12,
+    MIMPID_ADDR     = 12'hF13,
+    MHARTID_ADDR    = 12'hF14,
+    MCONFIGPTR_ADDR = 12'hF15,
+
+    /* Machine Trap Setup */
+    MSTATUS_ADDR    = 12'h300,
+    MISA_ADDR       = 12'h301,
+    MEDELEG_ADDR    = 12'h302,
+    MIDELEG_ADDR    = 12'h303,
+    MIE_ADDR        = 12'h304,
+    MTVEC_ADDR      = 12'h305,
+    MCOUNTEREN_ADDR = 12'h306,
+    MSTATUSH_ADDR   = 13'h310,
+
+    /* Machine Trap Handling */
+    MSCRATCH_ADDR   = 12'h340,
+    MEPC_ADDR       = 12'h341,
+    MCAUSE_ADDR     = 12'h342,
+    MTVAL_ADDR      = 12'h343,
+    MIP_ADDR        = 12'h344,
+    MTINST_ADDR     = 12'h34A,
+    MTVAL2_ADDR     = 12'h34B,
+
+    /* Machine Configuration */
+    MENVCFG_ADDR    = 12'h30A,
+    MENVCFGH_ADDR   = 12'h31A,
+    MSECCFG_ADDR    = 12'h747,
+    MSECCFGH_ADDR   = 12'h757,
+
+    /* Machine Memory Protection */
+    /* See pmp_types_1_12_pkg.sv */
+
+    /* Machine Counter/Timers */
+    MCYCLE_ADDR         = 12'hB00,
+    MINSTRET_ADDR       = 12'hB02,
+    MHPMCOUNTER3_ADDR   = 12'hB03,
+    MHPMCOUNTER4_ADDR   = 12'hB04,
+    MHPMCOUNTER5_ADDR   = 12'hB05,
+    MHPMCOUNTER6_ADDR   = 12'hB06,
+    MHPMCOUNTER7_ADDR   = 12'hB07,
+    MHPMCOUNTER8_ADDR   = 12'hB08,
+    MHPMCOUNTER9_ADDR   = 12'hB09,
+    MHPMCOUNTER10_ADDR  = 12'hB0A,
+    MHPMCOUNTER11_ADDR  = 12'hB0B,
+    MHPMCOUNTER12_ADDR  = 12'hB0C,
+    MHPMCOUNTER13_ADDR  = 12'hB0D,
+    MHPMCOUNTER14_ADDR  = 12'hB0E,
+    MHPMCOUNTER15_ADDR  = 12'hB0F,
+    MHPMCOUNTER16_ADDR  = 12'hB10,
+    MHPMCOUNTER17_ADDR  = 12'hB11,
+    MHPMCOUNTER18_ADDR  = 12'hB12,
+    MHPMCOUNTER19_ADDR  = 12'hB13,
+    MHPMCOUNTER20_ADDR  = 12'hB14,
+    MHPMCOUNTER21_ADDR  = 12'hB15,
+    MHPMCOUNTER22_ADDR  = 12'hB16,
+    MHPMCOUNTER23_ADDR  = 12'hB17,
+    MHPMCOUNTER24_ADDR  = 12'hB18,
+    MHPMCOUNTER25_ADDR  = 12'hB19,
+    MHPMCOUNTER26_ADDR  = 12'hB1A,
+    MHPMCOUNTER27_ADDR  = 12'hB1B,
+    MHPMCOUNTER28_ADDR  = 12'hB1C,
+    MHPMCOUNTER29_ADDR  = 12'hB1D,
+    MHPMCOUNTER30_ADDR  = 12'hB1E,
+    MHPMCOUNTER31_ADDR  = 12'hB1F,
+    MCYCLEH_ADDR        = 12'hB80,
+    MINSTRETH_ADDR      = 12'hB82,
+    MHPMCOUNTER3H_ADDR  = 12'hB83,
+    MHPMCOUNTER4H_ADDR  = 12'hB84,
+    MHPMCOUNTER5H_ADDR  = 12'hB85,
+    MHPMCOUNTER6H_ADDR  = 12'hB86,
+    MHPMCOUNTER7H_ADDR  = 12'hB87,
+    MHPMCOUNTER8H_ADDR  = 12'hB88,
+    MHPMCOUNTER9H_ADDR  = 12'hB89,
+    MHPMCOUNTER10H_ADDR = 12'hB8A,
+    MHPMCOUNTER11H_ADDR = 12'hB8B,
+    MHPMCOUNTER12H_ADDR = 12'hB8C,
+    MHPMCOUNTER13H_ADDR = 12'hB8D,
+    MHPMCOUNTER14H_ADDR = 12'hB8E,
+    MHPMCOUNTER15H_ADDR = 12'hB8F,
+    MHPMCOUNTER16H_ADDR = 12'hB90,
+    MHPMCOUNTER17H_ADDR = 12'hB91,
+    MHPMCOUNTER18H_ADDR = 12'hB92,
+    MHPMCOUNTER19H_ADDR = 12'hB93,
+    MHPMCOUNTER20H_ADDR = 12'hB94,
+    MHPMCOUNTER21H_ADDR = 12'hB95,
+    MHPMCOUNTER22H_ADDR = 12'hB96,
+    MHPMCOUNTER23H_ADDR = 12'hB97,
+    MHPMCOUNTER24H_ADDR = 12'hB98,
+    MHPMCOUNTER25H_ADDR = 12'hB99,
+    MHPMCOUNTER26H_ADDR = 12'hB9A,
+    MHPMCOUNTER27H_ADDR = 12'hB9B,
+    MHPMCOUNTER28H_ADDR = 12'hB9C,
+    MHPMCOUNTER29H_ADDR = 12'hB9D,
+    MHPMCOUNTER30H_ADDR = 12'hB9E,
+    MHPMCOUNTER31H_ADDR = 12'hB9F,
+
+    /* Machine Counter Setup */
+    MCOUNTINHIBIT_ADDR = 12'h320,
+    MHPMEVENT3_ADDR    = 12'h323,
+    MHPMEVENT4_ADDR    = 12'h324,
+    MHPMEVENT5_ADDR    = 12'h325,
+    MHPMEVENT6_ADDR    = 12'h326,
+    MHPMEVENT7_ADDR    = 12'h327,
+    MHPMEVENT8_ADDR    = 12'h328,
+    MHPMEVENT9_ADDR    = 12'h329,
+    MHPMEVENT10_ADDR   = 12'h32A,
+    MHPMEVENT11_ADDR   = 12'h32B,
+    MHPMEVENT12_ADDR   = 12'h32C,
+    MHPMEVENT13_ADDR   = 12'h32D,
+    MHPMEVENT14_ADDR   = 12'h32E,
+    MHPMEVENT15_ADDR   = 12'h32F,
+    MHPMEVENT16_ADDR   = 12'h330,
+    MHPMEVENT17_ADDR   = 12'h331,
+    MHPMEVENT18_ADDR   = 12'h332,
+    MHPMEVENT19_ADDR   = 12'h333,
+    MHPMEVENT20_ADDR   = 12'h334,
+    MHPMEVENT21_ADDR   = 12'h335,
+    MHPMEVENT22_ADDR   = 12'h336,
+    MHPMEVENT23_ADDR   = 12'h337,
+    MHPMEVENT24_ADDR   = 12'h338,
+    MHPMEVENT25_ADDR   = 12'h339,
+    MHPMEVENT26_ADDR   = 12'h33A,
+    MHPMEVENT27_ADDR   = 12'h33B,
+    MHPMEVENT28_ADDR   = 12'h33C,
+    MHPMEVENT29_ADDR   = 12'h33D,
+    MHPMEVENT30_ADDR   = 12'h33E,
+    MHPMEVENT31_ADDR   = 12'h33F
+  } mcsr_addr_t;
+
+
+  /* Machine Mode Register Types */
+
+  /* misaid types */
+
+  typedef enum logic [1:0] {
+    BASE_RV32   = 2'h1,
+    BASE_RV64   = 2'h2,
+    BASE_RV128  = 2'h3
+  } misaid_base_t;
+
+  typedef struct packed {
+    misaid_base_t base;
+    logic [3:0] zero;
+    logic [25:0] extensions;
+  } misaid_t;5
+
+  parameter MISAID_EXT_A   = 26'h1 << 0;
+  parameter MISAID_EXT_B   = 26'h1 << 1;
+  parameter MISAID_EXT_C   = 26'h1 << 2;
+  parameter MISAID_EXT_D   = 26'h1 << 3;
+  parameter MISAID_EXT_E   = 26'h1 << 4;
+  parameter MISAID_EXT_F   = 26'h1 << 5;
+  parameter MISAID_EXT_G   = 26'h1 << 6;
+  parameter MISAID_EXT_H   = 26'h1 << 7;
+  parameter MISAID_EXT_I   = 26'h1 << 8;
+  parameter MISAID_EXT_J   = 26'h1 << 9;
+  parameter MISAID_EXT_K   = 26'h1 << 10;
+  parameter MISAID_EXT_L   = 26'h1 << 11;
+  parameter MISAID_EXT_M   = 26'h1 << 12;
+  parameter MISAID_EXT_N   = 26'h1 << 13;
+  parameter MISAID_EXT_O   = 26'h1 << 14;
+  parameter MISAID_EXT_P   = 26'h1 << 15;
+  parameter MISAID_EXT_Q   = 26'h1 << 16;
+  parameter MISAID_EXT_R   = 26'h1 << 17;
+  parameter MISAID_EXT_S   = 26'h1 << 18;
+  parameter MISAID_EXT_T   = 26'h1 << 19;
+  parameter MISAID_EXT_U   = 26'h1 << 20;
+  parameter MISAID_EXT_V   = 26'h1 << 21;
+  parameter MISAID_EXT_W   = 26'h1 << 22;
+  parameter MISAID_EXT_X   = 26'h1 << 23;
+  parameter MISAID_EXT_Y   = 26'h1 << 24;
+  parameter MISAID_EXT_Z   = 26'h1 << 25;
+
+  /* mstatus types */
+
+  typedef enum logic [1:0] {
+    FS_OFF = 2'h0,
+    FS_INITIAL = 2'h1,
+    FS_CLEAN    = 2'h2,
+    FS_DIRTY    = 2'h3
+  } fs_t;
+
+  typedef enum logic [1:0] {
+    VS_OFF = 2'h0,
+    VS_INITIAL = 2'h1,
+    VS_CLEAN    = 2'h2,
+    VS_DIRTY    = 2'h3
+  } vs_t;
+
+  typedef enum logic [1:0] {
+    XS_ALL_OFF  = 2'h0,
+    XS_NONE_DC  = 2'h1,
+    XS_NONE_D   = 2'h2,
+    XS_SOME_D   = 2'h3
+  } xs_t;
+
+  typedef enum logic [1:0] {
+    U_MODE  = 2'h0,
+    S_MODE  = 2'h1,
+    RESERVED_MODE   = 2'h2,
+    M_MODE   = 2'h3
+  } priv_level_t;
+
+  typedef struct packed {
+    logic        sd;            // Extension dirty signal (R/O)
+    logic [7:0]  reserved_3;
+    logic        tsr;           // Trap SRET (no effect without S-Mode)
+    logic        tw;            // Timeout wait
+    logic        tvm;           // Trap virtual memory (no effect without S-Mode)
+    logic        mxr;           // Make executable readable (no effect without S-Mode)
+    logic        sum;           // Supervisor user memory access (no effect without S-Mode)
+    logic        mprv;          // Modify privilege
+    xs_t         xs;            // User extensions state
+    fs_t         fs;            // FP extension state
+    priv_level_t mpp;           // Previous privilege level
+    vs_t         vs;            // Vector extension state
+    logic        spp;           //
+    logic        mpie;          // M-Mode previous enable
+    logic        ube;           // U-Mode endianness control
+    logic 	     spie;          // S-Mode previous enable
+    logic        reserved_2;
+    logic	       mie            // M-Mode interrupt enable
+    logic        reserved_1;
+    logic 	     sie;           // S-Mode interrupt enable
+    logic        reserved_0;
+  } mstatus_t;
+
+ typedef struct packed {
+   logic [25:0] reserved_1;
+   logic        mbe;          // M-Mode endianness control
+   logic        sbe;          // S-Mode endianness control
+   logic [3:0]  reserved_0;
+ } mstatush_t;
+
+  /* mtvec types */
+ typedef enum logic [1:0] {
+    DIRECT   = 2'h0,
+    VECTORED = 2'h1
+  } vector_modes_t;
+
+  typedef struct packed {
+    logic [29:0] base;
+    vector_modes_t mode;
+  } mtvec_t;
+
+  /* mip and mie types */
+
+  // Decreasing priority: MEI, MSI, MTI
+
+  typedef struct packed {
+    logic [15:0] impl_defined; // Implementation defined
+    logic [3:0]  zero_6;
+    logic        meip;         // M-Mode external interrupt
+    logic        zero_5;
+    logic        seip;         // S-Mode external interrupt
+    logic        zero_4;
+    logic        mtip;         // M-Mode timer interrupt
+    logic        zero_3;
+    logic        stip;         // S-Mode timer interrupt
+    logic        zero_2;
+    logic        msip;         // M-Mode software interrupt
+    logic        zero_1;
+    logic        ssip;         // S-Mode software interrupt
+    logic        zero_0;
+  } mip_t;
+
+  typedef struct packed {
+    logic [15:0] impl_defined;
+    logic [3:0]  zero_6;
+    logic        meie;
+    logic        zero_5;
+    logic        seie;
+    logic        zero_4;
+    logic        mtie;
+    logic        zero_3;
+    logic        stie;
+    logic        zero_2;
+    logic        msie;
+    logic        zero_1;
+    logic        ssie;
+    logic        zero_0;
+  } mie_t;
+
+  /* mcounteren and mcountinhibit types */
+ typedef struct packed {
+   logic hpm31;
+   logic hpm30;
+   logic hpm29;
+   logic hpm28;
+   logic hpm27;
+   logic hpm26;
+   logic hpm25;
+   logic hpm24;
+   logic hpm23;
+   logic hpm22;
+   logic hpm21;
+   logic hpm20;
+   logic hpm19;
+   logic hpm18;
+   logic hpm17;
+   logic hpm16;
+   logic hpm15;
+   logic hpm14;
+   logic hpm13;
+   logic hpm12;
+   logic hpm11;
+   logic hpm10;
+   logic hpm9;
+   logic hpm8;
+   logic hpm7;
+   logic hpm6;
+   logic hpm5;
+   logic hpm4;
+   logic hpm3;
+   logic ir;
+   logic tm;
+   logic cy;
+ } mcounteren_t;
+
+  typedef struct packed {
+   logic hpm31;
+   logic hpm30;
+   logic hpm29;
+   logic hpm28;
+   logic hpm27;
+   logic hpm26;
+   logic hpm25;
+   logic hpm24;
+   logic hpm23;
+   logic hpm22;
+   logic hpm21;
+   logic hpm20;
+   logic hpm19;
+   logic hpm18;
+   logic hpm17;
+   logic hpm16;
+   logic hpm15;
+   logic hpm14;
+   logic hpm13;
+   logic hpm12;
+   logic hpm11;
+   logic hpm10;
+   logic hpm9;
+   logic hpm8;
+   logic hpm7;
+   logic hpm6;
+   logic hpm5;
+   logic hpm4;
+   logic hpm3;
+   logic ir;
+   logic tm;
+   logic cy;
+  } mcountinhibit_t;
+
+  /* mcause register variables */
+
+  typedef struct packed {
+    logic         interrupt;
+    logic [30:0]  cause;
+  } mcause_t;
+
+  // ex_code_t should be cast from an
+  // instantiation of mcause_t
+  typedef enum logic [30:0] {
+    INSN_MAL      = 31'd0,
+    INSN_ACCESS   = 31'd1,
+    ILLEGAL_INSN  = 31'd2,
+    BREAKPOINT    = 31'd3,
+    L_ADDR_MAL    = 31'd4,
+    L_FAULT       = 31'd5,
+    S_ADDR_MAL    = 31'd6,
+    S_FAULT       = 31'd7,
+    ENV_CALL_U    = 31'd8,
+    ENV_CALL_S    = 31'd9,
+    ENV_CALL_M    = 31'd11,
+    INSN_PAGE     = 31'd12,
+    LOAD_PAGE     = 31'd13,
+    STORE_PAGE    = 31'd15,
+  } ex_code_t;
+
+  typedef enum logic [30:0] {
+    SOFT_INT_S          = 31'd1,
+    SOFT_INT_M          = 31'd3,
+    TIMER_INT_S         = 31'd5,
+    TIMER_INT_M         = 31'd7,
+    EXT_INT_S           = 31'd9,
+    EXT_INT_M           = 31'd11
+  } int_code_t;
+
+  //Non Standard Extentions
+  typedef logic [31:0] mtohost_t;
+  typedef logic [31:0] mfromhost_t;
+
+endpackage
+
+`endif //MACHINE_MODE_TYPES_1_12_PKG_SV

--- a/source_code/packages/machine_mode_types_1_12_pkg.sv
+++ b/source_code/packages/machine_mode_types_1_12_pkg.sv
@@ -176,7 +176,7 @@ package machine_mode_types_1_12_pkg;
     misaid_base_t base;
     logic [3:0] zero;
     logic [25:0] extensions;
-  } misaid_t;5
+  } misaid_t;
 
   parameter MISAID_EXT_A   = 26'h1 << 0;
   parameter MISAID_EXT_B   = 26'h1 << 1;
@@ -248,12 +248,12 @@ package machine_mode_types_1_12_pkg;
     fs_t         fs;            // FP extension state
     priv_level_t mpp;           // Previous privilege level
     vs_t         vs;            // Vector extension state
-    logic        spp;           //
+    logic        spp;           // Supervisor previous privilege level (no effect without S-Mode)
     logic        mpie;          // M-Mode previous enable
     logic        ube;           // U-Mode endianness control
     logic 	     spie;          // S-Mode previous enable
     logic        reserved_2;
-    logic	       mie            // M-Mode interrupt enable
+    logic	       mie;           // M-Mode interrupt enable
     logic        reserved_1;
     logic 	     sie;           // S-Mode interrupt enable
     logic        reserved_0;
@@ -269,7 +269,9 @@ package machine_mode_types_1_12_pkg;
   /* mtvec types */
  typedef enum logic [1:0] {
     DIRECT   = 2'h0,
-    VECTORED = 2'h1
+    VECTORED = 2'h1,
+    RES_0    = 2'h2,
+    RES_1    = 2'h3
   } vector_modes_t;
 
   typedef struct packed {
@@ -382,7 +384,7 @@ package machine_mode_types_1_12_pkg;
    logic hpm4;
    logic hpm3;
    logic ir;
-   logic tm;
+   logic reserved_0;
    logic cy;
   } mcountinhibit_t;
 
@@ -409,7 +411,7 @@ package machine_mode_types_1_12_pkg;
     ENV_CALL_M    = 31'd11,
     INSN_PAGE     = 31'd12,
     LOAD_PAGE     = 31'd13,
-    STORE_PAGE    = 31'd15,
+    STORE_PAGE    = 31'd15
   } ex_code_t;
 
   typedef enum logic [30:0] {
@@ -420,6 +422,9 @@ package machine_mode_types_1_12_pkg;
     EXT_INT_S           = 31'd9,
     EXT_INT_M           = 31'd11
   } int_code_t;
+
+  // General CSR definition
+  typedef logic [31:0] csr_reg_t;
 
   //Non Standard Extentions
   typedef logic [31:0] mtohost_t;

--- a/source_code/packages/machine_mode_types_1_12_pkg.sv
+++ b/source_code/packages/machine_mode_types_1_12_pkg.sv
@@ -425,8 +425,11 @@ package machine_mode_types_1_12_pkg;
 
   // General CSR definition
   typedef logic [31:0] csr_reg_t;
+  typedef logic [63:0] long_csr_t;
 
   //Non Standard Extentions
+  // Unsure what these are for,
+  //  part of priv 1.11
   typedef logic [31:0] mtohost_t;
   typedef logic [31:0] mfromhost_t;
 

--- a/source_code/packages/machine_mode_types_1_12_pkg.sv
+++ b/source_code/packages/machine_mode_types_1_12_pkg.sv
@@ -44,7 +44,7 @@ package machine_mode_types_1_12_pkg;
     MIE_ADDR        = 12'h304,
     MTVEC_ADDR      = 12'h305,
     MCOUNTEREN_ADDR = 12'h306,
-    MSTATUSH_ADDR   = 13'h310,
+    MSTATUSH_ADDR   = 12'h310,
 
     /* Machine Trap Handling */
     MSCRATCH_ADDR   = 12'h340,

--- a/source_code/packages/pmp_types_1_12_pkg.sv
+++ b/source_code/packages/pmp_types_1_12_pkg.sv
@@ -1,0 +1,144 @@
+/*
+*   Copyright 2016 Purdue University
+*
+*   Licensed under the Apache License, Version 2.0 (the "License");
+*   you may not use this file except in compliance with the License.
+*   You may obtain a copy of the License at
+*
+*       http://www.apache.org/licenses/LICENSE-2.0
+*
+*   Unless required by applicable law or agreed to in writing, software
+*   distributed under the License is distributed on an "AS IS" BASIS,
+*   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*   See the License for the specific language governing permissions and
+*   limitations under the License.
+*
+*
+*   Filename:     pmp_types_1_12_pkg.sv
+*
+*   Created by:   Hadi Ahmed
+*   Email:        ahmed138@purdue.edu
+*   Date Created: 03/20/2022
+*   Description:  Types needed to implement physical memory protection
+*/
+
+`ifndef PMP_TYPES_1_12_PKG_SV
+`define PMP_TYPES_1_12_PKG_SV
+
+package pmp_types_1_12_pkg;
+
+  /* PMP CSR Addresses */
+  typedef enum logic [11:0] {
+    /* Machine Memory Protection */
+    PMPCFG0_ADDR   = 12'h3A0,
+    PMPCFG1_ADDR   = 12'h3A1,
+    PMPCFG2_ADDR   = 12'h3A2,
+    PMPCFG3_ADDR   = 12'h3A3,
+    PMPCFG4_ADDR   = 12'h3A4,
+    PMPCFG5_ADDR   = 12'h3A5,
+    PMPCFG6_ADDR   = 12'h3A6,
+    PMPCFG7_ADDR   = 12'h3A7,
+    PMPCFG8_ADDR   = 12'h3A8,
+    PMPCFG9_ADDR   = 12'h3A9,
+    PMPCFG10_ADDR  = 12'h3AA,
+    PMPCFG11_ADDR  = 12'h3AB,
+    PMPCFG12_ADDR  = 12'h3AC,
+    PMPCFG13_ADDR  = 12'h3AD,
+    PMPCFG14_ADDR  = 12'h3AE,
+    PMPCFG15_ADDR  = 12'h3AF,
+    PMPADDR0_ADDR  = 12'h3B0,
+    PMPADDR1_ADDR  = 12'h3B1,
+    PMPADDR2_ADDR  = 12'h3B2,
+    PMPADDR3_ADDR  = 12'h3B3,
+    PMPADDR4_ADDR  = 12'h3B4,
+    PMPADDR5_ADDR  = 12'h3B5,
+    PMPADDR6_ADDR  = 12'h3B6,
+    PMPADDR7_ADDR  = 12'h3B7,
+    PMPADDR8_ADDR  = 12'h3B8,
+    PMPADDR9_ADDR  = 12'h3B9,
+    PMPADDR10_ADDR = 12'h3BA,
+    PMPADDR11_ADDR = 12'h3BB,
+    PMPADDR12_ADDR = 12'h3BC,
+    PMPADDR13_ADDR = 12'h3BD,
+    PMPADDR14_ADDR = 12'h3BE,
+    PMPADDR15_ADDR = 12'h3BF,
+    PMPADDR16_ADDR = 12'h3C0,
+    PMPADDR17_ADDR = 12'h3C1,
+    PMPADDR18_ADDR = 12'h3C2,
+    PMPADDR19_ADDR = 12'h3C3,
+    PMPADDR20_ADDR = 12'h3C4,
+    PMPADDR21_ADDR = 12'h3C5,
+    PMPADDR22_ADDR = 12'h3C6,
+    PMPADDR23_ADDR = 12'h3C7,
+    PMPADDR24_ADDR = 12'h3C8,
+    PMPADDR25_ADDR = 12'h3C9,
+    PMPADDR26_ADDR = 12'h3CA,
+    PMPADDR27_ADDR = 12'h3CB,
+    PMPADDR28_ADDR = 12'h3CC,
+    PMPADDR29_ADDR = 12'h3CD,
+    PMPADDR30_ADDR = 12'h3CE
+    PMPADDR31_ADDR = 12'h3CF,
+    PMPADDR32_ADDR = 12'h3D0,
+    PMPADDR33_ADDR = 12'h3D1,
+    PMPADDR34_ADDR = 12'h3D2,
+    PMPADDR35_ADDR = 12'h3D3,
+    PMPADDR36_ADDR = 12'h3D4,
+    PMPADDR37_ADDR = 12'h3D5,
+    PMPADDR38_ADDR = 12'h3D6,
+    PMPADDR39_ADDR = 12'h3D7,
+    PMPADDR40_ADDR = 12'h3D8,
+    PMPADDR41_ADDR = 12'h3D9,
+    PMPADDR42_ADDR = 12'h3DA,
+    PMPADDR43_ADDR = 12'h3DB,
+    PMPADDR44_ADDR = 12'h3DC,
+    PMPADDR45_ADDR = 12'h3DD,
+    PMPADDR46_ADDR = 12'h3DE,
+    PMPADDR47_ADDR = 12'h3DF,
+    PMPADDR48_ADDR = 12'h3E0,
+    PMPADDR49_ADDR = 12'h3E1,
+    PMPADDR50_ADDR = 12'h3E2,
+    PMPADDR51_ADDR = 12'h3E3,
+    PMPADDR52_ADDR = 12'h3E4,
+    PMPADDR53_ADDR = 12'h3E5,
+    PMPADDR54_ADDR = 12'h3E6,
+    PMPADDR55_ADDR = 12'h3E7,
+    PMPADDR56_ADDR = 12'h3E8,
+    PMPADDR57_ADDR = 12'h3E9,
+    PMPADDR58_ADDR = 12'h3EA,
+    PMPADDR59_ADDR = 12'h3EB,
+    PMPADDR60_ADDR = 12'h3EC,
+    PMPADDR61_ADDR = 12'h3ED,
+    PMPADDR62_ADDR = 12'h3EE,
+    PMPADDR63_ADDR = 12'h3EF
+  } pmp_addr_t;
+
+  /* pmpcfg types */
+
+  typedef enum logic [1:0] {
+    OFF   = 2'b00,
+    TOR   = 2'b01,
+    NA4   = 2'b10,
+    NAPOT = 2'b11
+  } pmp_mode_t;
+
+ typedef struct packed {
+   logic       L;
+   logic [1:0] reserved;
+   pmp_mode_t  A;
+   logic       X;
+   logic       W;
+   logic       R;
+ } pmpcfg_base_t;
+
+typedef struct packed {
+  pmpcfg_base_t cfg3;
+  pmpcfg_base_t cfg2;
+  pmpcfg_base_t cfg1;
+  pmpcfg_base_t cfg0;
+} pmpcfg_t;
+
+typedef logic [31:0] pmpaddr_t;
+
+endpackage;
+
+`endif //PMP_TYPES_1_12_PKG_SV

--- a/source_code/packages/pmp_types_1_12_pkg.sv
+++ b/source_code/packages/pmp_types_1_12_pkg.sv
@@ -76,7 +76,7 @@ package pmp_types_1_12_pkg;
     PMPADDR27_ADDR = 12'h3CB,
     PMPADDR28_ADDR = 12'h3CC,
     PMPADDR29_ADDR = 12'h3CD,
-    PMPADDR30_ADDR = 12'h3CE
+    PMPADDR30_ADDR = 12'h3CE,
     PMPADDR31_ADDR = 12'h3CF,
     PMPADDR32_ADDR = 12'h3D0,
     PMPADDR33_ADDR = 12'h3D1,
@@ -139,6 +139,6 @@ typedef struct packed {
 
 typedef logic [31:0] pmpaddr_t;
 
-endpackage;
+endpackage
 
 `endif //PMP_TYPES_1_12_PKG_SV

--- a/source_code/pipelines/tspp/tspp_fetch_stage.sv
+++ b/source_code/pipelines/tspp/tspp_fetch_stage.sv
@@ -41,8 +41,8 @@ module tspp_fetch_stage (
 );
   import rv32i_types_pkg::*;
 
-  ///parameter RESET_PC = 32'h200;
-  parameter RESET_PC = 32'h80000000;
+  parameter RESET_PC = 32'h200;
+  //parameter RESET_PC = 32'h80000000;
 
   word_t  pc, pc4or2, npc, instr;
 

--- a/source_code/pipelines/tspp/tspp_fetch_stage.sv
+++ b/source_code/pipelines/tspp/tspp_fetch_stage.sv
@@ -41,8 +41,8 @@ module tspp_fetch_stage (
 );
   import rv32i_types_pkg::*;
 
-  parameter RESET_PC = 32'h200;
-  //parameter RESET_PC = 32'h80000000;
+  //parameter RESET_PC = 32'h200;
+  parameter RESET_PC = 32'h80000000;
 
   word_t  pc, pc4or2, npc, instr;
 

--- a/source_code/privs/priv_1_12/priv_1_12_block.sv
+++ b/source_code/privs/priv_1_12/priv_1_12_block.sv
@@ -36,6 +36,8 @@ module priv_1_12_block (
 
     priv_1_12_internal_if prv_intern_if();
 
+    priv_1_12_csr csr (.CLK(CLK), .nRST(nRST), .prv_intern_if(prv_intern_if));
+
     priv_level_t curr_priv;
 
     assign prv_intern_if.curr_priv = M_MODE; // TODO make this changeable

--- a/source_code/privs/priv_1_12/priv_1_12_block.sv
+++ b/source_code/privs/priv_1_12/priv_1_12_block.sv
@@ -38,8 +38,12 @@ module priv_1_12_block (
 
     priv_level_t curr_priv;
 
-    assign prv_pip_if.curr_priv = M_MODE; // TODO make this changeable
+    assign prv_intern_if.curr_priv = M_MODE; // TODO make this changeable
     assign prv_intern_if.inst_ret = prv_pipe_if.wb_enable & prv_pipe_if.instr;
-
+    assign prv_intern_if.csr_addr = prv_pipe_if.maddr;
+    assign prv_intern_if.csr_mod = prv_pipe_if.swap | prv_pipe_if.clr | prv_pipe_if.set;
+    assign prv_intern_if.new_csr_val = prv_pipe_if.wdata;
+    assign prv_pipe_if.rdata = prv_intern_if.old_csr_val;
+    assign prv_pipe_if.invalid_csr = prv_intern_if.invalid_csr;
 
 endmodule

--- a/source_code/privs/priv_1_12/priv_1_12_block.sv
+++ b/source_code/privs/priv_1_12/priv_1_12_block.sv
@@ -28,13 +28,13 @@
 
 module priv_1_12_block (
     input logic CLK, nRST,
-    prv_pipeline_if.prv_block prv_pipe_if,
+    prv_pipeline_if.priv_block prv_pipe_if,
     core_interrupt_if.core interrupt_if
 );
 
     import machine_mode_types_1_12_pkg::*;
 
-    priv_1_12_internal_if priv_int_if();
+    priv_1_12_internal_if prv_intern_if();
 
     priv_level_t curr_priv;
 

--- a/source_code/privs/priv_1_12/priv_1_12_block.sv
+++ b/source_code/privs/priv_1_12/priv_1_12_block.sv
@@ -43,7 +43,9 @@ module priv_1_12_block (
     assign prv_intern_if.curr_priv = M_MODE; // TODO make this changeable
     assign prv_intern_if.inst_ret = prv_pipe_if.wb_enable & prv_pipe_if.instr;
     assign prv_intern_if.csr_addr = prv_pipe_if.maddr;
-    assign prv_intern_if.csr_mod = prv_pipe_if.swap | prv_pipe_if.clr | prv_pipe_if.set;
+    assign prv_intern_if.csr_write = prv_pipe_if.swap;
+    assign prv_intern_if.csr_clear = prv_pipe_if.clr;
+    assign prv_intern_if.csr_set = prv_pipe_if.set;
     assign prv_intern_if.new_csr_val = prv_pipe_if.wdata;
     assign prv_pipe_if.rdata = prv_intern_if.old_csr_val;
     assign prv_pipe_if.invalid_csr = prv_intern_if.invalid_csr;

--- a/source_code/privs/priv_1_12/priv_1_12_block.sv
+++ b/source_code/privs/priv_1_12/priv_1_12_block.sv
@@ -14,23 +14,32 @@
 *   limitations under the License.
 *
 *
-*   Filename:     priv_wrapper.sv
+*   Filename:     priv_1_12_block.sv
 *
-*   Created by:   John Skubic
-*   Email:        jskubic@purdue.edu
-*   Date Created: 05/18/2017
-*   Description:  Top level wrapper for the priv ISA implementation.
+*   Created by:   Hadi Ahmed
+*   Email:        ahmed138@purdue.edu
+*   Date Created: 03/27/2022
+*   Description:  Top level block for the privileged unit, v1.12
 */
 
 `include "prv_pipeline_if.vh"
+`include "priv_1_12_internal_if.vh"
 `include "core_interrupt_if.vh"
 
-module priv_wrapper (
-  input logic CLK, nRST,
-  prv_pipeline_if.priv_block prv_pipe_if,
-  core_interrupt_if.core interrupt_if
+module priv_1_12_block (
+    input logic CLK, nRST,
+    prv_pipeline_if.prv_block prv_pipe_if,
+    core_interrupt_if.core interrupt_if
 );
 
-  priv_1_12_block priv_block_i(.*);
+    import machine_mode_types_1_12_pkg::*;
+
+    priv_1_12_internal_if priv_int_if();
+
+    priv_level_t curr_priv;
+
+    assign curr_priv = M_MODE; // TODO make this changeable
+
+
 
 endmodule

--- a/source_code/privs/priv_1_12/priv_1_12_block.sv
+++ b/source_code/privs/priv_1_12/priv_1_12_block.sv
@@ -38,8 +38,8 @@ module priv_1_12_block (
 
     priv_level_t curr_priv;
 
-    assign curr_priv = M_MODE; // TODO make this changeable
-
+    assign prv_pip_if.curr_priv = M_MODE; // TODO make this changeable
+    assign prv_intern_if.inst_ret = prv_pipe_if.wb_enable & prv_pipe_if.instr;
 
 
 endmodule

--- a/source_code/privs/priv_1_12/priv_1_12_csr.sv
+++ b/source_code/privs/priv_1_12/priv_1_12_csr.sv
@@ -1,0 +1,203 @@
+/*
+*   Copyright 2016 Purdue University
+*
+*   Licensed under the Apache License, Version 2.0 (the "License");
+*   you may not use this file except in compliance with the License.
+*   You may obtain a copy of the License at
+*
+*       http://www.apache.org/licenses/LICENSE-2.0
+*
+*   Unless required by applicable law or agreed to in writing, software
+*   distributed under the License is distributed on an "AS IS" BASIS,
+*   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*   See the License for the specific language governing permissions and
+*   limitations under the License.
+*
+*
+*   Filename:     priv_1_12_csr.sv
+*
+*   Created by:   Hadi Ahmed
+*   Email:        ahmed138@purdue.edu
+*   Date Created: 03/28/2022
+*   Description:  CSR File for Priv Unit 1.12
+*/
+
+`include "priv_1_12_internal_if.vh"
+`include "component_selection_defins.vh"
+
+module priv_1_12_csr # (
+  HARTID = 0 ) (
+  input CLK, nRST,
+  priv_1_12_internal_if.csr prv_intern_if
+);
+
+
+  import machine_mode_types_1_12_pkg::*;
+  import rv32i_types_pkg::*;
+
+  /* Machine Information */
+  csr_reg_t         mvendorid;
+  csr_reg_t         marchid;
+  csr_reg_t         mimpid;
+  csr_reg_t         mhartid;
+  csr_reg_t         mconfigptr;
+  /* Machine Trap Setup */
+  mstatus_t         mstatus;
+  misaid_t          misaid;
+  mie_t             mie;
+  mtvec_t           mtvec;
+  mstatush_t        mstatush;
+  /* Machine Trap Handling */
+  csr_reg_t         mscratch;
+  csr_reg_t         mepc;
+  mcause_t          mcause;
+  csr_reg_t         mtval;
+  mip_t             mip;
+  /* Machine Counters/Timers */
+  mcounteren_t      mcounteren;
+  mcounterinhibit_t mcounterinhibit;
+  csr_reg_t         mcycle;
+  csr_reg_t         minstret;
+  csr_reg_t         mcycleh;
+  csr_reg_t         minstreth;
+
+  csr_reg_t nxt_csr_val;
+
+  /* These info registers are always just tied to certain values */
+  assign mvendorid = '0;
+  assign marchid = '0;
+  assign mimpid = '0;
+  assign mconfigptr = '0;
+  assign mhartid = HARTID;
+
+  /* These registers have some RO fields */
+  assign misaid.zero = '0;
+  assign misaid.base = BASE_RV32;
+  assign misaid.extensions =      MISAID_EXT_I
+                            `ifdef RV32C_SUPPORTED
+                                | MISAID_EXT_C
+                            `endif `ifdef RV32E_SUPPORTED
+                                | MISAID_EXT_E
+                            `endif `ifdef RV32F_SUPPORTED
+                                | MISAID_EXT_F
+                            `endif `ifdef RV32M_SUPPORTED
+                                | MISAID_EXT_M
+                            `endif `ifdef RV32U_SUPPORTED
+                                | MISAID_EXT_U
+                            `endif `ifdef RV32V_SUPPORTED
+                                | MISAID_EXT_V
+                            `endif `ifdef CUSTOM_SUPPORTED
+                                | MISAID_EXT_X
+                            `endif;
+
+  assign mstatus.reserved_0 = '0;
+  assign mstatus.reserved_1 = '0;
+  assign mstatus.reserved_2 = '0;
+  assign mstatus.reserved_3 = '0;
+  assign mstatus.sie = 1'b0;
+  assign mstatus.spie = 1'b0;
+  assign mstatus.ube = 1'b0;
+  assign mstatus.spp = 1'b0;
+  assign mstatus.sum = 1'b0;
+  assign mstatus.mxr = 1'b0;
+  assign mstatus.tvm = 1'b0;
+  assign mstatus.tsr = 1'b0;
+  assign mstatus.sd = (mstatus.vs == VS_DIRTY) | (mstatus.fs == FS_DIRTY) | (mstatus.xs == XS_SOME_D);
+  `ifdef RV32V_SUPPORTED
+    assign mstatus.vs = VS_INITIAL;
+  `else
+    assign mstatus.vs = VS_OFF;
+  `endif
+  `ifdef RV32F_SUPPORTED
+    assign mstatus.fs = FS_INITIAL;
+  `else
+    assign mstatus.fs = FS_OFF;
+  `endif
+  `ifdef CUSTOM_SUPPORTED
+    assign mstatus.xs = XS_NONE_D;
+  `else
+    assign mstatus.xs = XS_ALL_OFF;
+  `endif
+
+  assign mstatush.reserved_0 = '0;
+  assign mstatush.sbe = 1'b0;
+  assign mstatush.mbe = 1'b0;
+  assign mstatush.reserved_1 = '0;
+
+  assign mip.zero_0 = '0;
+  assign mip.zero_1 = '0;
+  assign mip.zero_2 = '0;
+  assign mip.zero_3 = '0;
+  assign mip.zero_4 = '0;
+  assign mip.zero_5 = '0;
+  assign mip.zero_6 = '0;
+  assign mip.ssip = 1'b0;
+  assign mip.stip = 1'b0;
+  assign mip.seip = 1'b0;
+  assign mip.impl_defined = '0; // TODO do we want to define others?
+
+  assign mie.zero_0 = '0;
+  assign mie.zero_1 = '0;
+  assign mie.zero_2 = '0;
+  assign mie.zero_3 = '0;
+  assign mie.zero_4 = '0;
+  assign mie.zero_5 = '0;
+  assign mie.zero_6 = '0;
+  assign mie.ssie = 1'b0;
+  assign mie.stie = 1'b0;
+  assign mie.seie = 1'b0;
+  assign mip.impl_defined = '0; // TODO do we want to define others?
+
+  always_ff @ (posedge CLK, negedge nRST) begin
+    if (~nRST) begin
+      /* mstatus reset */
+      mstatus.mie <= 1'b1;
+      mstatus.mpie <= 1'b0;
+      mstatus.mpp <= M_MODE;
+      mstatus.mprv <= 1'b0;
+      mstatus.tw <= 1'b1;
+
+      /* mtvec reset */
+      mtvec.mode <= DIRECT; // TODO talk with cole about defaults
+      mtvec.base <= '0;     // TODO talk with cole about defaults
+
+      /* mie reset */
+      mie.msie <= 1'b0;
+      mie.mtie <= 1'b0;
+      mie.meie <= 1'b0;
+
+      /* mip reset */
+      mip.msip <= 1'b0;
+      mip.mtip <= 1'b0;
+      mip.meip <= 1'b0;
+
+      /* msratch reset */
+      mscratch <= '0;
+
+      /* mepc reset */
+      mepc <= '0;
+
+      /* mtval reset */
+      mtval <= '0;
+
+      /* mcounter reset */
+      mcounteren <= '1;
+      mcounterinhibit <= '1;
+
+      /* perf mon reset */
+      mcycle <= '0;
+      mcycleh <= '0;
+      minstret <= '0;
+      minstreth <= '0;
+
+      /* mcause reset */
+      mcause <= '0;
+
+    end else begin
+
+    end
+  end
+
+
+
+endmodule

--- a/source_code/privs/priv_1_12/priv_1_12_csr.sv
+++ b/source_code/privs/priv_1_12/priv_1_12_csr.sv
@@ -23,7 +23,7 @@
 */
 
 `include "priv_1_12_internal_if.vh"
-`include "component_selection_defins.vh"
+`include "component_selection_defines.vh"
 
 module priv_1_12_csr # (
   HARTID = 0 ) (
@@ -55,7 +55,7 @@ module priv_1_12_csr # (
   mip_t             mip;
   /* Machine Counters/Timers */
   mcounteren_t      mcounteren;
-  mcounterinhibit_t mcounterinhibit;
+  mcountinhibit_t   mcounterinhibit;
   csr_reg_t         mcycle;
   csr_reg_t         minstret;
   csr_reg_t         mcycleh;
@@ -154,7 +154,7 @@ module priv_1_12_csr # (
   assign mie.ssie = 1'b0;
   assign mie.stie = 1'b0;
   assign mie.seie = 1'b0;
-  assign mip.impl_defined = '0; // TODO do we want to define others?
+  assign mie.impl_defined = '0; // TODO do we want to define others?
 
   // Control and Status Registers
   always_ff @ (posedge CLK, negedge nRST) begin
@@ -207,12 +207,12 @@ module priv_1_12_csr # (
           MSTATUS_ADDR: begin
             mstatus.mie <= nxt_csr_val[3];
             mstatus.mpie <= nxt_csr_val[7];
-            mstatus.mpp <= nxt_csr_val[12:11];
+            mstatus.mpp <= priv_level_t'(nxt_csr_val[12:11]);
             mstatus.mprv <= nxt_csr_val[17];
             mstatus.tw <= nxt_csr_val[21];
           end
           MTVEC_ADDR: begin
-            mtvec.mode <= nxt_csr_val[1:0];
+            mtvec.mode <= vector_modes_t'(nxt_csr_val[1:0]);
             mtvec.base <= nxt_csr_val[31:2];
           end
           MIE_ADDR: begin
@@ -271,10 +271,10 @@ module priv_1_12_csr # (
 
         /* Below have no values to check or are R/O */
         MVENDORID_ADDR, MARCHID_ADDR, MIMPID_ADDR, MHARTID_ADDR, MCONFIGPTR_ADDR,
-        MISA_ADDR, MIE_ADDR, MTVEC_ADDR, MSTATUSH_ADDR, MSCRATCH_ADDR, MEPC_ADDR
+        MISA_ADDR, MIE_ADDR, MTVEC_ADDR, MSTATUSH_ADDR, MSCRATCH_ADDR, MEPC_ADDR,
         MCAUSE_ADDR, MTVAL_ADDR, MIP_ADDR, MCOUNTEREN_ADDR, MCOUNTINHIBIT_ADDR,
         MCYCLE_ADDR, MINSTRET_ADDR, MCYCLEH_ADDR, MINSTRETH_ADDR: begin
-            nxt_csr_val = priv_intern_if.curr_priv;
+            nxt_csr_val = prv_intern_if.curr_priv;
         end
 
 
@@ -292,7 +292,7 @@ module priv_1_12_csr # (
       cf_next = cycles_full + 1;
     end
     if (~mcounterinhibit.ir) begin
-      if_next = instret_full + priv_intern_if.inst_ret;
+      if_next = instret_full + prv_intern_if.inst_ret;
     end
   end
 
@@ -301,27 +301,28 @@ module priv_1_12_csr # (
     prv_intern_if.old_csr_val = '0;
     /* CPU return */
     casez(prv_intern_if.csr_addr)
-    MVENDORID_ADDR: prv_intern_if.old_csr_val = mvendorid;
-    MARCHID_ADDR: prv_intern_if.old_csr_val = marchid;
-    MIMPID_ADDR: prv_intern_if.old_csr_val = mimpid;
-    MHARTID_ADDR: prv_intern_if.old_csr_val = mhartid;
-    MCONFIGPTR_ADDR: prv_intern_if.old_csr_val = mconfigptr;
-    MSTATUS: prv_intern_if.old_csr_val = mstatus;
-    MISA_ADDR: prv_intern_if.old_csr_val = misaid;
-    MIE_ADDR: prv_intern_if.old_csr_val = mie;
-    MTVEC_ADDR: prv_intern_if.old_csr_val = mtvec;
-    MSTATUSH_ADDR: prv_intern_if.old_csr_val = mstatush;
-    MSCRATCH_ADDR: prv_intern_if.old_csr_val = mscratch;
-    MEPC_ADDR: prv_intern_if.old_csr_val = mepc;
-    MCAUSE_ADDR: prv_intern_if.old_csr_val = mcause;
-    MTVAL_ADDR: prv_intern_if.old_csr_val = mtval;
-    MIP_ADDR: prv_intern_if.old_csr_val = mip;
-    MCOUNTEREN_ADDR: prv_intern_if.old_csr_val = mcounteren;
-    MCOUNTINHIBIT_ADDR: prv_intern_if.old_csr_val = mcounterinhibit;
-    MCYCLE_ADDR: prv_intern_if.old_csr_val = mcycle;
-    MINSTRET_ADDR: prv_intern_if.old_csr_val = minstret;
-    MCYCLEH_ADDR: prv_intern_if.old_csr_val = mcycleh;
-    MINSTRETH_ADDR: prv_intern_if.old_csr_val = minstreth;
+      MVENDORID_ADDR: prv_intern_if.old_csr_val = mvendorid;
+      MARCHID_ADDR: prv_intern_if.old_csr_val = marchid;
+      MIMPID_ADDR: prv_intern_if.old_csr_val = mimpid;
+      MHARTID_ADDR: prv_intern_if.old_csr_val = mhartid;
+      MCONFIGPTR_ADDR: prv_intern_if.old_csr_val = mconfigptr;
+      MSTATUS_ADDR: prv_intern_if.old_csr_val = mstatus;
+      MISA_ADDR: prv_intern_if.old_csr_val = misaid;
+      MIE_ADDR: prv_intern_if.old_csr_val = mie;
+      MTVEC_ADDR: prv_intern_if.old_csr_val = mtvec;
+      MSTATUSH_ADDR: prv_intern_if.old_csr_val = mstatush;
+      MSCRATCH_ADDR: prv_intern_if.old_csr_val = mscratch;
+      MEPC_ADDR: prv_intern_if.old_csr_val = mepc;
+      MCAUSE_ADDR: prv_intern_if.old_csr_val = mcause;
+      MTVAL_ADDR: prv_intern_if.old_csr_val = mtval;
+      MIP_ADDR: prv_intern_if.old_csr_val = mip;
+      MCOUNTEREN_ADDR: prv_intern_if.old_csr_val = mcounteren;
+      MCOUNTINHIBIT_ADDR: prv_intern_if.old_csr_val = mcounterinhibit;
+      MCYCLE_ADDR: prv_intern_if.old_csr_val = mcycle;
+      MINSTRET_ADDR: prv_intern_if.old_csr_val = minstret;
+      MCYCLEH_ADDR: prv_intern_if.old_csr_val = mcycleh;
+      MINSTRETH_ADDR: prv_intern_if.old_csr_val = minstreth;
+    endcase
   end
 
 endmodule

--- a/source_code/privs/priv_1_12/priv_1_12_csr.sv
+++ b/source_code/privs/priv_1_12/priv_1_12_csr.sv
@@ -274,9 +274,8 @@ module priv_1_12_csr # (
         MISA_ADDR, MIE_ADDR, MTVEC_ADDR, MSTATUSH_ADDR, MSCRATCH_ADDR, MEPC_ADDR,
         MCAUSE_ADDR, MTVAL_ADDR, MIP_ADDR, MCOUNTEREN_ADDR, MCOUNTINHIBIT_ADDR,
         MCYCLE_ADDR, MINSTRET_ADDR, MCYCLEH_ADDR, MINSTRETH_ADDR: begin
-            nxt_csr_val = prv_intern_if.curr_priv;
+            nxt_csr_val = prv_intern_if.new_csr_val;
         end
-
 
         default: prv_intern_if.invalid_csr = 1'b1; // CSR address doesn't exist
       endcase

--- a/source_code/tb/tb_priv_1_12_block.sv
+++ b/source_code/tb/tb_priv_1_12_block.sv
@@ -24,8 +24,11 @@
 
 `timescale 1ns/100ps
 
+`include "rv32i_types_pkg.sv"
+`include "machine_mode_types_1_12_pkg.sv"
 `include "prv_pipeline_if.vh"
 `include "priv_1_12_internal_if.vh"
+`include "core_interrupt_if.vh"
 
 `define OUTPUT_FILE_NAME "cpu.hex"
 `define STATS_FILE_NAME "stats.txt"
@@ -45,12 +48,17 @@ parameter PERIOD = 20;
 
   //Interface Instantiations
   prv_pipeline_if prv_pipeline_if();
+  core_interrupt_if core_int_if();
+
+  // Package Instantiations
+  import machine_mode_types_1_12_pkg::*;
 
   //Module Instantiations
   priv_1_12_block DUT (
     .CLK(CLK),
     .nRST(nRST),
-    .prv_pipe_if(prv_pipeline_if) // using the "priv_block" modport of the prv_pieline_if.vh file
+    .prv_pipe_if(prv_pipeline_if),
+    .interrupt_if(core_int_if)
   );
 
   //Clock generation
@@ -66,29 +74,29 @@ parameter PERIOD = 20;
   initial begin : CORE_RUN
     nRST = 0;
 
-    prv_pieline_if.pipe_clear = '0;
-    prv_pieline_if.ret = '0;
-    prv_pieline_if.epc = '0;
-    prv_pieline_if.fault_insn = '0;
-    prv_pieline_if.mal_insn = '0;
-    prv_pieline_if.illegal_insn = '0;
-    prv_pieline_if.fault_l = '0;
-    prv_pieline_if.mal_l = '0;
-    prv_pieline_if.fault_s = '0;
-    prv_pieline_if.mal_s = '0;
-    prv_pieline_if.breakpoint = '0;
-    prv_pieline_if.env_m = '0;
-    prv_pieline_if.badaddr = '0;
-    prv_pieline_if.swap = '0;
-    prv_pieline_if.clr = '0;
-    prv_pieline_if.set = '0;
-    prv_pieline_if.wdata = '0;
-    prv_pieline_if.addr = '0;
-    prv_pieline_if.valid_write = '0;
-    prv_pieline_if.wb_enable = '0;
-    prv_pieline_if.instr = '0;
-    prv_pieline_if.ex_rmgmt = '0;
-    prv_pieline_if.ex_rmgmt_cause = '0;
+    prv_pipeline_if.pipe_clear = '0;
+    prv_pipeline_if.ret = '0;
+    prv_pipeline_if.epc = '0;
+    prv_pipeline_if.fault_insn = '0;
+    prv_pipeline_if.mal_insn = '0;
+    prv_pipeline_if.illegal_insn = '0;
+    prv_pipeline_if.fault_l = '0;
+    prv_pipeline_if.mal_l = '0;
+    prv_pipeline_if.fault_s = '0;
+    prv_pipeline_if.mal_s = '0;
+    prv_pipeline_if.breakpoint = '0;
+    prv_pipeline_if.env_m = '0;
+    prv_pipeline_if.badaddr = '0;
+    prv_pipeline_if.swap = '0;
+    prv_pipeline_if.clr = '0;
+    prv_pipeline_if.set = '0;
+    prv_pipeline_if.wdata = '0;
+    prv_pipeline_if.maddr = MSTATUS_ADDR;
+    prv_pipeline_if.valid_write = '0;
+    prv_pipeline_if.wb_enable = '0;
+    prv_pipeline_if.instr = '0;
+    prv_pipeline_if.ex_rmgmt = '0;
+    prv_pipeline_if.ex_rmgmt_cause = '0;
 
     @(posedge CLK);
     @(posedge CLK);

--- a/source_code/tb/tb_priv_1_12_block.sv
+++ b/source_code/tb/tb_priv_1_12_block.sv
@@ -231,6 +231,68 @@ module tb_priv_1_12_block ();
     #PROP_DELAY;
     test_num++;
 
+    // ****************
+    // Test Case 8: Emulate CSRRS to mscratch
+    // ***************
+    prv_pipeline_if.swap = 1'b0;
+    prv_pipeline_if.set = 1'b1;
+    prv_pipeline_if.wdata = 32'h21524110;
+    prv_pipeline_if.maddr = MSCRATCH_ADDR;
+    #PROP_DELAY;
+    if (prv_pipeline_if.rdata == 32'hdeadbeef)
+      $display("> Test %d: PASS", test_num);
+    else
+      $display("> Test %d: FAIL (got %h) (expected %h)", test_num, prv_pipeline_if.rdata, 32'hdeadbeef);
+    @(posedge CLK);
+    #PROP_DELAY;
+    test_num++;
+
+    // ****************
+    // Test Case 9: Emulate CSRRS to mscratch pt2
+    // ***************
+    prv_pipeline_if.set = 1'b1;
+    prv_pipeline_if.wdata = 32'h21524110;
+    prv_pipeline_if.maddr = MSCRATCH_ADDR;
+    #PROP_DELAY;
+    if (prv_pipeline_if.rdata == 32'hffffffff)
+      $display("> Test %d: PASS", test_num);
+    else
+      $display("> Test %d: FAIL (got %h) (expected %h)", test_num, prv_pipeline_if.rdata, 32'hffffffff);
+    @(posedge CLK);
+    #PROP_DELAY;
+    test_num++;
+
+    // ****************
+    // Test Case 10: Emulate CSRRC to mscratch
+    // ***************
+    prv_pipeline_if.set = 1'b0;
+    prv_pipeline_if.clr = 1'b1;
+    prv_pipeline_if.wdata = 32'hffffffff;
+    prv_pipeline_if.maddr = MSCRATCH_ADDR;
+    #PROP_DELAY;
+    if (prv_pipeline_if.rdata == 32'hffffffff)
+      $display("> Test %d: PASS", test_num);
+    else
+      $display("> Test %d: FAIL (got %h) (expected %h)", test_num, prv_pipeline_if.rdata, 32'hffffffff);
+    @(posedge CLK);
+    #PROP_DELAY;
+    test_num++;
+
+    // ****************
+    // Test Case 11: Emulate CSRRC to mscratch pt2
+    // ***************
+    prv_pipeline_if.clr = 1'b1;
+    prv_pipeline_if.wdata = 32'h0;
+    prv_pipeline_if.maddr = MSCRATCH_ADDR;
+    #PROP_DELAY;
+    if (prv_pipeline_if.rdata == 32'h0)
+      $display("> Test %d: PASS", test_num);
+    else
+      $display("> Test %d: FAIL (got %h) (expected %h)", test_num, prv_pipeline_if.rdata, 32'h0);
+    @(posedge CLK);
+    #PROP_DELAY;
+    test_num++;
+
 
     $display("==== Finishing tests");
     $display("\n");

--- a/source_code/tb/tb_priv_1_12_block.sv
+++ b/source_code/tb/tb_priv_1_12_block.sv
@@ -1,0 +1,101 @@
+/*
+*   Copyright 2016 Purdue University
+*
+*   Licensed under the Apache License, Version 2.0 (the "License");
+*   you may not use this file except in compliance with the License.
+*   You may obtain a copy of the License at
+*
+*       http://www.apache.org/licenses/LICENSE-2.0
+*
+*   Unless required by applicable law or agreed to in writing, software
+*   distributed under the License is distributed on an "AS IS" BASIS,
+*   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*   See the License for the specific language governing permissions and
+*   limitations under the License.
+*
+*
+*   Filename:		  tb_priv_1_12_block.sv
+*
+*   Created by:		Hadi Ahmed
+*   Email:			ahmed138@purdue.edu
+*   Date Created:	04/02/2022
+*   Description:	Testbench for running the privileged unit v1.12.
+*/
+
+`timescale 1ns/100ps
+
+`include "prv_pipeline_if.vh"
+`include "priv_1_12_internal_if.vh"
+
+`define OUTPUT_FILE_NAME "cpu.hex"
+`define STATS_FILE_NAME "stats.txt"
+`define RVB_CLK_TIMEOUT 10000
+
+module tb_priv_1_12_block ();
+
+parameter PERIOD = 20;
+
+  logic CLK, nRST;
+  logic ram_control; // 1 -> CORE, 0 -> TB
+  logic halt;
+  logic [31:0] addr, data_temp, data;
+  logic [63:0] hexdump_temp;
+  logic [7:0] checksum;
+  integer fptr, stats_ptr;
+
+  //Interface Instantiations
+  prv_pipeline_if prv_pipeline_if();
+
+  //Module Instantiations
+  priv_1_12_block DUT (
+    .CLK(CLK),
+    .nRST(nRST),
+    .prv_pipe_if(prv_pipeline_if) // using the "priv_block" modport of the prv_pieline_if.vh file
+  );
+
+  //Clock generation
+  initial begin : INIT
+    CLK = 0;
+  end : INIT
+
+  always begin : CLOCK_GEN
+    #(PERIOD/2) CLK = ~CLK;
+  end : CLOCK_GEN
+
+  //Setup core and let it run
+  initial begin : CORE_RUN
+    nRST = 0;
+
+    prv_pieline_if.pipe_clear = '0;
+    prv_pieline_if.ret = '0;
+    prv_pieline_if.epc = '0;
+    prv_pieline_if.fault_insn = '0;
+    prv_pieline_if.mal_insn = '0;
+    prv_pieline_if.illegal_insn = '0;
+    prv_pieline_if.fault_l = '0;
+    prv_pieline_if.mal_l = '0;
+    prv_pieline_if.fault_s = '0;
+    prv_pieline_if.mal_s = '0;
+    prv_pieline_if.breakpoint = '0;
+    prv_pieline_if.env_m = '0;
+    prv_pieline_if.badaddr = '0;
+    prv_pieline_if.swap = '0;
+    prv_pieline_if.clr = '0;
+    prv_pieline_if.set = '0;
+    prv_pieline_if.wdata = '0;
+    prv_pieline_if.addr = '0;
+    prv_pieline_if.valid_write = '0;
+    prv_pieline_if.wb_enable = '0;
+    prv_pieline_if.instr = '0;
+    prv_pieline_if.ex_rmgmt = '0;
+    prv_pieline_if.ex_rmgmt_cause = '0;
+
+    @(posedge CLK);
+    @(posedge CLK);
+    nRST = 1;
+
+    $finish;
+
+  end : CORE_RUN
+
+endmodule

--- a/source_code/tb/tb_priv_1_12_block.sv
+++ b/source_code/tb/tb_priv_1_12_block.sv
@@ -22,7 +22,7 @@
 *   Description:	Testbench for running the privileged unit v1.12.
 */
 
-`timescale 1ns/100ps
+`timescale 1ns/1ns
 
 `include "rv32i_types_pkg.sv"
 `include "machine_mode_types_1_12_pkg.sv"
@@ -36,7 +36,9 @@
 
 module tb_priv_1_12_block ();
 
-parameter PERIOD = 20;
+  parameter PERIOD = 10;
+
+  localparam PROP_DELAY = 1ns;
 
   logic CLK, nRST;
   logic ram_control; // 1 -> CORE, 0 -> TB
@@ -45,6 +47,8 @@ parameter PERIOD = 20;
   logic [63:0] hexdump_temp;
   logic [7:0] checksum;
   integer fptr, stats_ptr;
+
+  integer test_num;
 
   //Interface Instantiations
   prv_pipeline_if prv_pipeline_if();
@@ -72,7 +76,11 @@ parameter PERIOD = 20;
 
   //Setup core and let it run
   initial begin : CORE_RUN
+    $display("\n");
+    $display("==== Starting tests");
+
     nRST = 0;
+    test_num = 0;
 
     prv_pipeline_if.pipe_clear = '0;
     prv_pipeline_if.ret = '0;
@@ -102,6 +110,130 @@ parameter PERIOD = 20;
     @(posedge CLK);
     nRST = 1;
 
+    $display("=== DUT reset");
+
+    @(posedge CLK);
+    #PROP_DELAY;
+
+    $display("== CSR cases");
+    // ****************
+    // Test Case 0: Read mvendorid
+    // ***************
+    prv_pipeline_if.swap = 1'b1;
+    prv_pipeline_if.maddr = MVENDORID_ADDR;
+    #PROP_DELAY;
+    if (prv_pipeline_if.rdata == 32'b0)
+      $display("> Test %d: PASS", test_num);
+    else
+      $display("> Test %d: FAIL (got %h) (expected %h)", test_num, prv_pipeline_if.rdata, 32'b0);
+    @(posedge CLK);
+    #PROP_DELAY;
+    test_num++;
+
+    // ****************
+    // Test Case 1: Read marchid
+    // ***************
+    prv_pipeline_if.swap = 1'b1;
+    prv_pipeline_if.maddr = MARCHID_ADDR;
+    #PROP_DELAY;
+    if (prv_pipeline_if.rdata == 32'b0)
+      $display("> Test %d: PASS", test_num);
+    else
+      $display("> Test %d: FAIL (got %b) (expected %b)", test_num, prv_pipeline_if.rdata, 32'b0);
+    @(posedge CLK);
+    #PROP_DELAY;
+    test_num++;
+
+    // ****************
+    // Test Case 2: Read mimpid
+    // ***************
+    prv_pipeline_if.swap = 1'b1;
+    prv_pipeline_if.maddr = MIMPID_ADDR;
+    #PROP_DELAY;
+    if (prv_pipeline_if.rdata == 32'b0)
+      $display("> Test %d: PASS", test_num);
+    else
+      $display("> Test %d: FAIL (got %b) (expected %b)", test_num, prv_pipeline_if.rdata, 32'b0);
+    @(posedge CLK);
+    #PROP_DELAY;
+    test_num++;
+
+    // ****************
+    // Test Case 3: Read mhartid
+    // ***************
+    prv_pipeline_if.swap = 1'b1;
+    prv_pipeline_if.maddr = MHARTID_ADDR;
+    #PROP_DELAY;
+    if (prv_pipeline_if.rdata == 32'b0)
+      $display("> Test %d: PASS", test_num);
+    else
+      $display("> Test %d: FAIL (got %b) (expected %b)", test_num, prv_pipeline_if.rdata, 32'b0);
+    @(posedge CLK);
+    #PROP_DELAY;
+    test_num++;
+
+    // ****************
+    // Test Case 4: Read mconfigptr
+    // ***************
+    prv_pipeline_if.swap = 1'b1;
+    prv_pipeline_if.maddr = MCONFIGPTR_ADDR;
+    #PROP_DELAY;
+    if (prv_pipeline_if.rdata == 32'b0)
+      $display("> Test %d: PASS", test_num);
+    else
+      $display("> Test %d: FAIL (got %b) (expected %b)", test_num, prv_pipeline_if.rdata, 32'b0);
+    @(posedge CLK);
+    #PROP_DELAY;
+    test_num++;
+
+    // ****************
+    // Test Case 5: Emulate CSRRW to mstatus
+    // ***************
+    prv_pipeline_if.swap = 1'b1;
+    prv_pipeline_if.wdata = 32'h1088;
+    prv_pipeline_if.maddr = MSTATUS_ADDR;
+    #PROP_DELAY;
+    if (prv_pipeline_if.rdata == 32'h201800)
+      $display("> Test %d: PASS", test_num);
+    else
+      $display("> Test %d: FAIL (got %h) (expected %h)", test_num, prv_pipeline_if.rdata, 32'h201800);
+    @(posedge CLK);
+    #PROP_DELAY;
+    test_num++;
+
+    // ****************
+    // Test Case 6: Emulate CSRRW to mstatus pt2
+    // ***************
+    prv_pipeline_if.swap = 1'b1;
+    prv_pipeline_if.wdata = 32'h00001088;
+    prv_pipeline_if.maddr = MSTATUS_ADDR;
+    #PROP_DELAY;
+    if (prv_pipeline_if.rdata == 32'h88)
+      $display("> Test %d: PASS", test_num);
+    else
+      $display("> Test %d: FAIL (got %h) (expected %h)", test_num, prv_pipeline_if.rdata, 32'h88);
+    @(posedge CLK);
+    #PROP_DELAY;
+    test_num++;
+
+    // ****************
+    // Test Case 7: Emulate CSRRW to mscratch
+    // ***************
+    prv_pipeline_if.swap = 1'b1;
+    prv_pipeline_if.wdata = 32'hdeadbeef;
+    prv_pipeline_if.maddr = MSCRATCH_ADDR;
+    #PROP_DELAY;
+    if (prv_pipeline_if.rdata == 32'h0)
+      $display("> Test %d: PASS", test_num);
+    else
+      $display("> Test %d: FAIL (got %h) (expected %h)", test_num, prv_pipeline_if.rdata, 32'h0);
+    @(posedge CLK);
+    #PROP_DELAY;
+    test_num++;
+
+
+    $display("==== Finishing tests");
+    $display("\n");
     $finish;
 
   end : CORE_RUN


### PR DESCRIPTION
This Pull Request adds a framework for the privileged v1.12 unit updates. Only the CSR file is updated, with all required machine mode registers implemented. This update also properly implements all CSR based instructions.

Notes: this pull request has **not been tested with the full core**. While I am pretty sure it should work, I have yet to be able to run test cases with it. I can confirm the component-level testbench works with no issues.

This pull request also breaks any interrupt handling. I am going to add that back in slowly.

Future work:
 - Reexamine the interrupt architecture: CLINT w PLIC vs CLIC
 - Add a variable privilege level: Machine or User
 - Create an extendible interface for extensions to add CSRs they add and modify to the main CSR block without needing significant work