### PR TITLE
Bus fault handler

### DIFF
--- a/source_code/bus_bridges/ahb.sv
+++ b/source_code/bus_bridges/ahb.sv
@@ -86,6 +86,7 @@ module ahb (
 
     assign out_gen_bus_if.busy  = state == IDLE || ~((ahb_m.HREADY && (state == DATA)));
     assign out_gen_bus_if.rdata = ahb_m.HRDATA;
+    assign out_gen_bus_if.error = ahb_m.HRESP;
     // Unused signals
     assign ahb_m.HMASTLOCK = 1'b0;
     assign ahb_m.HBURST = 3'b000;

--- a/source_code/bus_bridges/generic_nonpipeline.sv
+++ b/source_code/bus_bridges/generic_nonpipeline.sv
@@ -56,5 +56,6 @@ module generic_nonpipeline (
     assign pipeline_trans_if.busy = (out_gen_bus_if.addr == 0) ? 1 : out_gen_bus_if.busy;
     assign pipeline_trans_if.rdata = out_gen_bus_if.rdata;
     assign next_wdata = pipeline_trans_if.wdata;
+    assign pipeline_trans_if.error = out_gen_bus_if.error;
 
 endmodule

--- a/source_code/caches/l1/l1_cache.sv
+++ b/source_code/caches/l1/l1_cache.sv
@@ -264,7 +264,7 @@ module l1_cache #(
 		            next_last_used[decoded_addr.idx_bits] = hit_idx;
                 end
                 // passthrough
-                else if(pass_through) begin
+                else if(pass_through && (proc_gen_bus_if.wen || proc_gen_bus_if.ren)) begin
                     mem_gen_bus_if.wen      = proc_gen_bus_if.wen;
                     mem_gen_bus_if.ren      = proc_gen_bus_if.ren;
                     mem_gen_bus_if.addr     = proc_gen_bus_if.addr;
@@ -389,13 +389,13 @@ module l1_cache #(
                     next_state = FLUSH_CACHE;
 	        end
 	        FETCH: begin
-                if (mem_gen_bus_if.error || decoded_addr != decoded_req_addr)
+                if (mem_gen_bus_if.error || decoded_addr != decoded_req_addr || !(proc_gen_bus_if.ren || proc_gen_bus_if.wen))
                     next_state = HIT; 
                 else if (word_count_done)
                     next_state = HIT;
 	        end
 	        WB: begin
-                if (mem_gen_bus_if.error || decoded_addr != decoded_req_addr)
+                if (mem_gen_bus_if.error || decoded_addr != decoded_req_addr || !(proc_gen_bus_if.ren || proc_gen_bus_if.wen))
                     next_state = HIT; 
                 else if (word_count_done)
                     next_state = FETCH;

--- a/source_code/caches/l1/l1_cache.sv
+++ b/source_code/caches/l1/l1_cache.sv
@@ -112,6 +112,9 @@ module l1_cache #(
     logic flush_req, nflush_req;
     logic idle_done;
 
+    // error handling
+    assign proc_gen_bus_if.error = mem_gen_bus_if.error;
+
     // sram instance
     assign sramSEL = (state == FLUSH_CACHE || state == IDLE) ? flush_idx.set_num : decoded_addr.idx_bits;
     sram #(.SRAM_WR_SIZE(SRAM_W), .SRAM_HEIGHT(N_SETS)) 
@@ -386,13 +389,13 @@ module l1_cache #(
                     next_state = FLUSH_CACHE;
 	        end
 	        FETCH: begin
-                if (decoded_addr != decoded_req_addr)
+                if (mem_gen_bus_if.error || decoded_addr != decoded_req_addr)
                     next_state = HIT; 
                 else if (word_count_done)
                     next_state = HIT;
 	        end
 	        WB: begin
-                if (decoded_addr != decoded_req_addr)
+                if (mem_gen_bus_if.error || decoded_addr != decoded_req_addr)
                     next_state = HIT; 
                 else if (word_count_done)
                     next_state = FETCH;

--- a/source_code/caches/l1/l1_wrapper.sv
+++ b/source_code/caches/l1/l1_wrapper.sv
@@ -1,0 +1,12 @@
+
+
+module l1_wrapper();
+
+    generic_bus_if mem_gen_bus_if();
+    generic_bus_if proc_gen_bus_if();
+
+    logic CLK, nRST, clear, flush, clear_done, flush_done;
+
+    l1_cache DUT(.*);
+
+endmodule

--- a/source_code/caches/pass_through/pass_through_cache.sv
+++ b/source_code/caches/pass_through/pass_through_cache.sv
@@ -40,5 +40,6 @@ module pass_through_cache (
 
     assign proc_gen_bus_if.rdata  = mem_gen_bus_if.rdata;
     assign proc_gen_bus_if.busy   = mem_gen_bus_if.busy;
+    assign proc_gen_bus_if.error  = mem_gen_bus_if.error;
 
 endmodule

--- a/source_code/include/generic_bus_if.vh
+++ b/source_code/include/generic_bus_if.vh
@@ -33,15 +33,16 @@ interface generic_bus_if ();
   word_t rdata;
   logic ren,wen;
   logic busy;
+  logic error;
   logic [3:0] byte_en;
 
   modport generic_bus (
     input addr, ren, wen, wdata, byte_en,
-    output rdata, busy
+    output rdata, busy, error
   );
 
   modport cpu (
-    input rdata, busy,
+    input rdata, busy, error,
     output addr, ren, wen, wdata, byte_en
   );
 

--- a/source_code/include/prv_pipeline_if.vh
+++ b/source_code/include/prv_pipeline_if.vh
@@ -77,6 +77,7 @@ interface prv_pipeline_if();
   );
 
   modport fetch (
+    input prot_fault_i,
     output iren, iaddr, i_acc_width
   );
 

--- a/source_code/pipelines/stage3/source/stage3_fetch_stage.sv
+++ b/source_code/pipelines/stage3/source/stage3_fetch_stage.sv
@@ -85,7 +85,7 @@ module stage3_fetch_stage (
                  : pc4or2))));
 
     //Instruction Access logic
-    assign hazard_if.i_mem_busy = igen_bus_if.busy;
+    assign hazard_if.i_mem_busy = igen_bus_if.busy && !fault_insn;
     assign igen_bus_if.addr = rv32cif.rv32c_ena ? rv32cif.imem_pc : pc;
     assign igen_bus_if.ren = hazard_if.iren && !rv32cif.done_earlier && !hazard_if.suppress_iren;
     assign igen_bus_if.wen = 1'b0;

--- a/source_code/pipelines/stage3/source/stage3_fetch_stage.sv
+++ b/source_code/pipelines/stage3/source/stage3_fetch_stage.sv
@@ -49,6 +49,12 @@ module stage3_fetch_stage (
     parameter logic [31:0] RESET_PC = 32'h80000000;
 
     word_t pc, pc4or2, npc, instr;
+    
+    //Send exceptions through pipeline
+    logic mal_addr;
+    logic fault_insn;
+    logic mal_insn;
+    word_t badaddr;
 
     //PC logic
 
@@ -92,11 +98,6 @@ module stage3_fetch_stage (
     assign igen_bus_if.byte_en = 4'b1111;
     assign igen_bus_if.wdata = '0;
 
-    //Send exceptions through pipeline
-    logic mal_addr;
-    logic fault_insn;
-    logic mal_insn;
-    word_t badaddr;
 
     assign mal_addr = (igen_bus_if.addr[1:0] != 2'b00);
     assign fault_insn = prv_pipe_if.prot_fault_i || (igen_bus_if.ren && igen_bus_if.error); // TODO: Set this up to fault on bus error

--- a/source_code/pipelines/stage3/source/stage3_fetch_stage.sv
+++ b/source_code/pipelines/stage3/source/stage3_fetch_stage.sv
@@ -99,7 +99,7 @@ module stage3_fetch_stage (
     word_t badaddr;
 
     assign mal_addr = (igen_bus_if.addr[1:0] != 2'b00);
-    assign fault_insn = 1'b0;
+    assign fault_insn = prv_pipe_if.prot_fault_i; // TODO: Set this up to fault on bus error
     assign mal_insn = mal_addr;
     assign badaddr = igen_bus_if.addr;
     assign hazard_if.pc_f = pc;
@@ -113,6 +113,13 @@ module stage3_fetch_stage (
         if (!nRST) fetch_ex_if.fetch_ex_reg <= '0;
         else if (hazard_if.if_ex_flush && !hazard_if.if_ex_stall) fetch_ex_if.fetch_ex_reg <= '0;
         else if (!hazard_if.if_ex_stall) begin
+            if(mal_insn || fault_insn) begin
+                // Squash to NOP if exception
+                // Still valid for exception handling
+                fetch_ex_if.fetch_ex_reg.instr <= '0;
+            end else begin
+                fetch_ex_if.fetch_ex_reg.instr      <= instr_to_ex;
+            end
             fetch_ex_if.fetch_ex_reg.valid      <= 1'b1;
             fetch_ex_if.fetch_ex_reg.token      <= 1'b1;
             fetch_ex_if.fetch_ex_reg.mal_insn   <= mal_insn;
@@ -120,7 +127,6 @@ module stage3_fetch_stage (
             fetch_ex_if.fetch_ex_reg.badaddr    <= badaddr;
             fetch_ex_if.fetch_ex_reg.pc         <= pc;
             fetch_ex_if.fetch_ex_reg.pc4        <= pc4or2;
-            fetch_ex_if.fetch_ex_reg.instr      <= instr_to_ex;
             fetch_ex_if.fetch_ex_reg.prediction <= predict_if.predict_taken; // TODO: This is just wrong...
         end
     end

--- a/source_code/pipelines/stage3/source/stage3_fetch_stage.sv
+++ b/source_code/pipelines/stage3/source/stage3_fetch_stage.sv
@@ -99,7 +99,7 @@ module stage3_fetch_stage (
     word_t badaddr;
 
     assign mal_addr = (igen_bus_if.addr[1:0] != 2'b00);
-    assign fault_insn = prv_pipe_if.prot_fault_i; // TODO: Set this up to fault on bus error
+    assign fault_insn = prv_pipe_if.prot_fault_i || (igen_bus_if.ren && igen_bus_if.error); // TODO: Set this up to fault on bus error
     assign mal_insn = mal_addr;
     assign badaddr = igen_bus_if.addr;
     assign hazard_if.pc_f = pc;

--- a/source_code/pipelines/stage3/source/stage3_hazard_unit.sv
+++ b/source_code/pipelines/stage3/source/stage3_hazard_unit.sv
@@ -78,7 +78,7 @@ module stage3_hazard_unit (
 
     /* Hazards due to Interrupts/Exceptions */
     assign prv_pipe_if.ret = hazard_if.ret;
-    assign exception  = hazard_if.fault_insn | hazard_if.mal_insn | prv_pipe_if.prot_fault_i
+    assign exception  = hazard_if.fault_insn | hazard_if.mal_insn // | prv_pipe_if.prot_fault_i
                       | hazard_if.illegal_insn | hazard_if.fault_l | hazard_if.mal_l
                       | hazard_if.fault_s | hazard_if.mal_s | hazard_if.breakpoint
                       | hazard_if.env | prv_pipe_if.prot_fault_l | prv_pipe_if.prot_fault_s;
@@ -109,7 +109,7 @@ module stage3_hazard_unit (
                                     hazard_if.jump |
                                     hazard_if.branch; //Because 2 stages
 
-    assign prv_pipe_if.fault_insn = hazard_if.fault_insn | prv_pipe_if.prot_fault_i;
+    assign prv_pipe_if.fault_insn = hazard_if.fault_insn;// | prv_pipe_if.prot_fault_i;
     assign prv_pipe_if.mal_insn = hazard_if.mal_insn;
     assign prv_pipe_if.illegal_insn = hazard_if.illegal_insn;
     assign prv_pipe_if.fault_l = hazard_if.fault_l | prv_pipe_if.prot_fault_l;

--- a/source_code/pipelines/stage3/source/stage3_mem_stage.sv
+++ b/source_code/pipelines/stage3/source/stage3_mem_stage.sv
@@ -204,9 +204,9 @@ module stage3_mem_stage(
     assign hazard_if.fault_insn = ex_mem_if.ex_mem_reg.fault_insn;
     assign hazard_if.mal_insn = ex_mem_if.ex_mem_reg.mal_insn;
     assign hazard_if.illegal_insn = ex_mem_if.ex_mem_reg.illegal_insn || prv_pipe_if.invalid_priv_isn;
-    assign hazard_if.fault_l = 1'b0;
+    assign hazard_if.fault_l = ex_mem_if.ex_mem_reg.dren && dgen_bus_if.error;
     assign hazard_if.mal_l = ex_mem_if.ex_mem_reg.dren & mal_addr;
-    assign hazard_if.fault_s = 1'b0;
+    assign hazard_if.fault_s = ex_mem_if.ex_mem_reg.dwen && dgen_bus_if.error;
     assign hazard_if.mal_s = ex_mem_if.ex_mem_reg.dwen & mal_addr;
     assign hazard_if.breakpoint = ex_mem_if.ex_mem_reg.breakpoint;
     assign hazard_if.env = ex_mem_if.ex_mem_reg.ecall_insn;

--- a/source_code/ram/ram_wrapper.sv
+++ b/source_code/ram/ram_wrapper.sv
@@ -36,6 +36,7 @@ module ram_wrapper (
 
     logic [RAM_ADDR_SIZE-3:0] word_addr;
     assign word_addr = gen_bus_if.addr[WORD_SIZE-1:2];
+    assign gen_bus_if.error = (gen_bus_if.addr < 32'h8000_0000);
 
     ram_sim_model #(
         .LAT(0),

--- a/source_code/standard_core/memory_controller.sv
+++ b/source_code/standard_core/memory_controller.sv
@@ -143,7 +143,9 @@ module memory_controller (
                 out_gen_bus_if.addr    = 0;
                 out_gen_bus_if.byte_en = d_gen_bus_if.byte_en;
                 d_gen_bus_if.busy      = 1'b1;
+                d_gen_bus_if.error     = 1'b0;
                 i_gen_bus_if.busy      = 1'b1;
+                i_gen_bus_if.error     = 1'b0;
             end
 
             //-- INSTRUCTION REQUEST --//
@@ -154,7 +156,9 @@ module memory_controller (
                 out_gen_bus_if.addr    = i_gen_bus_if.addr;
                 out_gen_bus_if.byte_en = i_gen_bus_if.byte_en;
                 d_gen_bus_if.busy      = 1'b1;
+                d_gen_bus_if.error     = 1'b0;
                 i_gen_bus_if.busy      = 1'b1;
+                i_gen_bus_if.error     = 1'b0;
             end
             INSTR_DATA_REQ: begin
                 out_gen_bus_if.wen     = d_gen_bus_if.wen;
@@ -162,7 +166,9 @@ module memory_controller (
                 out_gen_bus_if.addr    = d_gen_bus_if.addr;
                 out_gen_bus_if.byte_en = i_gen_bus_if.byte_en;
                 i_gen_bus_if.busy      = out_gen_bus_if.busy;
+                i_gen_bus_if.error     = out_gen_bus_if.error;
                 d_gen_bus_if.busy      = 1'b1;
+                d_gen_bus_if.error     = 1'b0;
             end
             INSTR_WAIT: begin
                 out_gen_bus_if.wen     = 0;
@@ -170,7 +176,9 @@ module memory_controller (
                 out_gen_bus_if.addr    = 0;
                 out_gen_bus_if.byte_en = i_gen_bus_if.byte_en;
                 d_gen_bus_if.busy      = 1'b1;
+                d_gen_bus_if.error     = 1'b0;
                 i_gen_bus_if.busy      = out_gen_bus_if.busy;
+                i_gen_bus_if.error     = out_gen_bus_if.error;
             end
 
             //-- DATA REQUEST --//
@@ -180,7 +188,9 @@ module memory_controller (
                 out_gen_bus_if.addr    = d_gen_bus_if.addr;
                 out_gen_bus_if.byte_en = d_gen_bus_if.byte_en;
                 d_gen_bus_if.busy      = 1'b1;
+                d_gen_bus_if.error     = 1'b0;
                 i_gen_bus_if.busy      = 1'b1;
+                i_gen_bus_if.error     = 1'b0;
             end
             DATA_INSTR_REQ: begin
                 out_gen_bus_if.wen     = i_gen_bus_if.wen;
@@ -188,7 +198,9 @@ module memory_controller (
                 out_gen_bus_if.addr    = i_gen_bus_if.addr;
                 out_gen_bus_if.byte_en = d_gen_bus_if.byte_en;
                 d_gen_bus_if.busy      = out_gen_bus_if.busy;
+                d_gen_bus_if.error     = out_gen_bus_if.error;
                 i_gen_bus_if.busy      = 1'b1;
+                i_gen_bus_if.error     = 1'b0;
             end
             DATA_WAIT: begin
                 //out_gen_bus_if.wen     = d_gen_bus_if.wen;
@@ -199,7 +211,9 @@ module memory_controller (
                 out_gen_bus_if.addr    = 0;
                 out_gen_bus_if.byte_en = d_gen_bus_if.byte_en;
                 i_gen_bus_if.busy      = 1'b1;
+                i_gen_bus_if.error     = 1'b0;
                 d_gen_bus_if.busy      = out_gen_bus_if.busy;
+                d_gen_bus_if.error     = out_gen_bus_if.error;
             end
 
             CANCEL_REQ_WAIT: begin
@@ -208,7 +222,9 @@ module memory_controller (
                 out_gen_bus_if.addr    = 0;
                 out_gen_bus_if.byte_en = 0;
                 i_gen_bus_if.busy      = 1;
+                i_gen_bus_if.error     = 0;
                 d_gen_bus_if.busy      = 1;
+                d_gen_bus_if.error     = 0;
             end
 
             default: begin
@@ -217,7 +233,9 @@ module memory_controller (
                 out_gen_bus_if.addr    = 0;
                 out_gen_bus_if.byte_en = d_gen_bus_if.byte_en;
                 d_gen_bus_if.busy      = 1'b1;
+                d_gen_bus_if.error     = 1'b0;
                 i_gen_bus_if.busy      = 1'b1;
+                i_gen_bus_if.error     = 1'b0;
             end
         endcase
     end

--- a/source_code/standard_core/top_core.sv
+++ b/source_code/standard_core/top_core.sv
@@ -13,6 +13,7 @@ module top_core #(
     // generic bus if case
 `ifdef BUS_INTERFACE_GENERIC_BUS
     input busy,
+    input error,
     input [31:0] rdata,
     output ren,
     wen,
@@ -74,6 +75,7 @@ module top_core #(
     generic_bus_if gen_bus_if ();
     assign gen_bus_if.busy = busy;
     assign gen_bus_if.rdata = rdata;
+    assign gen_bus_if.error = error;
     assign ren = gen_bus_if.ren;
     assign wen = gen_bus_if.wen;
     assign byte_en = gen_bus_if.byte_en;

--- a/tb_core.cc
+++ b/tb_core.cc
@@ -281,12 +281,15 @@ int main(int argc, char **argv) {
 
     reset(dut, m_trace);
     while(!dut.halt && sim_time < 100000) {
+        dut.error = 0;
         // TODO: Variable latency
         if((dut.ren || dut.wen) && dut.busy) {
             dut.busy = 0;
             if(dut.ren) {
                 uint32_t addr = dut.addr & 0xFFFFFFFC;
-                if(!MemoryMap::is_mmio_region(addr)) {
+                if(addr < 0x80000000) {
+                    dut.error = 1;
+                }else if(!MemoryMap::is_mmio_region(addr)) {
                     dut.rdata = memory.read(addr);
                 } else {
                     dut.rdata = memory.mmio_read(addr);
@@ -295,7 +298,9 @@ int main(int argc, char **argv) {
                 uint32_t addr = dut.addr & 0xFFFFFFFC;
                 uint32_t value = dut.wdata;
                 uint8_t mask = dut.byte_en;
-                if(!MemoryMap::is_mmio_region(addr)) {
+                if(addr < 0x80000000) {
+                    dut.error = 1;
+                } else if(!MemoryMap::is_mmio_region(addr)) {
                     memory.write(addr, value, mask);
                 } else {
                     memory.mmio_write(addr, value, mask);

--- a/tb_core.cc
+++ b/tb_core.cc
@@ -19,6 +19,7 @@
 #define EXT_ADDR_SET    0xFFFFFFF4
 #define EXT_ADDR_CLEAR  0xFFFFFFF8
 #define MAGIC_ADDR      0xFFFFFFFC
+#define BUS_ERROR_TOP   0x20000000
 
 // Inclusive range of memory-mapped peripherals
 #define MMIO_RANGE_BEGIN (MTIME_ADDR)
@@ -287,7 +288,7 @@ int main(int argc, char **argv) {
             dut.busy = 0;
             if(dut.ren) {
                 uint32_t addr = dut.addr & 0xFFFFFFFC;
-                if(addr < 0x80000000) {
+                if(addr < BUS_ERROR_TOP) {
                     dut.error = 1;
                 }else if(!MemoryMap::is_mmio_region(addr)) {
                     dut.rdata = memory.read(addr);
@@ -298,7 +299,7 @@ int main(int argc, char **argv) {
                 uint32_t addr = dut.addr & 0xFFFFFFFC;
                 uint32_t value = dut.wdata;
                 uint8_t mask = dut.byte_en;
-                if(addr < 0x80000000) {
+                if(addr < BUS_ERROR_TOP) {
                     dut.error = 1;
                 } else if(!MemoryMap::is_mmio_region(addr)) {
                     memory.write(addr, value, mask);

--- a/verification/interrupts-exceptions/build_all.py
+++ b/verification/interrupts-exceptions/build_all.py
@@ -6,7 +6,7 @@ import os
 import pathlib
 
 
-compile_cmd = ['riscv64-unknown-elf-gcc', '-march=rv32i', '-mabi=ilp32', '-mcmodel=medany',
+compile_cmd = ['riscv64-unknown-elf-gcc', '-march=rv32i_zicsr', '-mabi=ilp32', '-mcmodel=medany',
                 '-static', '-nostdlib', '-O2', '-Tlink.ld', 'start.S', 'utility.c']
 
 cvt_cmd = ['riscv64-unknown-elf-objcopy', '-O', 'binary']

--- a/verification/interrupts-exceptions/bus_fault.c
+++ b/verification/interrupts-exceptions/bus_fault.c
@@ -1,0 +1,39 @@
+#include <stdint.h>
+#include "utility.h"
+
+extern int flag;
+
+void __attribute__((interrupt)) __attribute__((aligned(4))) handler() {
+    uint32_t mepc_value;
+    asm volatile("csrr %0, mepc" : "=r"(mepc_value));
+    mepc_value += 4;
+    asm volatile("csrw mepc, %0" : : "r"(mepc_value));
+    /*
+    asm volatile(
+        "mv t0, zero; csrrs t0, mepc, t0; addi t0, t0, 4; csrw mepc, t0;"
+        :
+        :
+        : "t0"
+    );*/
+    print("Made it to handler!\n");
+    flag = 1;
+}
+
+int main() {
+    uint32_t mtvec_value = (uint32_t)handler;
+    uint32_t mstatus_value = 0x8;
+
+    asm volatile("csrw mstatus, %0" : : "r" (mstatus_value));
+    asm volatile("csrw mtvec, %0" : : "r" (mtvec_value));
+
+    print("Read 0x0\n");
+    int x = *(volatile int *)(0x4);
+
+    if(flag != 1) {
+        print("Failed!\n");
+    } else {
+        print("Bus fault, pass!\n");
+    }
+
+    return 0;
+}

--- a/verification/pma-tests/build_all.py
+++ b/verification/pma-tests/build_all.py
@@ -6,7 +6,7 @@ import os
 import pathlib
 
 
-compile_cmd = ['riscv64-unknown-elf-gcc', '-march=rv32i', '-mabi=ilp32', '-mcmodel=medany',
+compile_cmd = ['riscv64-unknown-elf-gcc', '-march=rv32i_zicsr', '-mabi=ilp32', '-mcmodel=medany',
                 '-static', '-nostdlib', '-O2', '-Tlink.ld', 'start.S', 'utility.c']
 
 cvt_cmd = ['riscv64-unknown-elf-objcopy', '-O', 'binary']

--- a/verification/pma-tests/pma_i.c
+++ b/verification/pma-tests/pma_i.c
@@ -12,11 +12,16 @@ volatile uint32_t *pma_ram_addr = (uint32_t*) PMA_RAM_ADDR;
 void __attribute__((interrupt)) __attribute__((aligned(4))) handler() {
     // In a real program, a fault should be handled differently
     uint32_t mepc_value;
+    uint32_t mtval_value;
     asm volatile("csrr %0, mepc" : "=r"(mepc_value));
+    asm volatile("csrr %0, mtval" : "=r"(mtval_value));
     mepc_value = (uint32_t)done; // return to the spot after we did the bad jump
     asm volatile("csrw mepc, %0" : : "r"(mepc_value));
 
     print("PMA Checker failed (expected)\n");
+    print("MTVAL: ");
+    put_uint32_hex(mtval_value);
+    print("\n");
     flag = 1;
 }
 

--- a/verification/pmp-tests/build_all.py
+++ b/verification/pmp-tests/build_all.py
@@ -6,7 +6,7 @@ import os
 import pathlib
 
 
-compile_cmd = ['riscv64-unknown-elf-gcc', '-march=rv32i', '-mabi=ilp32', '-mcmodel=medany',
+compile_cmd = ['riscv64-unknown-elf-gcc', '-march=rv32i_zicsr', '-mabi=ilp32', '-mcmodel=medany',
                 '-static', '-nostdlib', '-O2', '-Tlink.ld', 'start.S', 'utility.c']
 
 cvt_cmd = ['riscv64-unknown-elf-objcopy', '-O', 'binary']

--- a/verification/u-mode/build_all.py
+++ b/verification/u-mode/build_all.py
@@ -6,7 +6,7 @@ import os
 import pathlib
 
 
-compile_cmd = ['riscv64-unknown-elf-gcc', '-march=rv32i', '-mabi=ilp32', '-mcmodel=medany',
+compile_cmd = ['riscv64-unknown-elf-gcc', '-march=rv32i_zicsr', '-mabi=ilp32', '-mcmodel=medany',
                 '-static', '-nostdlib', '-O2', '-Tlink.ld', 'start.S', 'utility.c']
 
 cvt_cmd = ['riscv64-unknown-elf-objcopy', '-O', 'binary']


### PR DESCRIPTION
This fixes the RISC-V core ignoring bus errors by:
1. Adding an "error" signal to generic_bus_if
2. Propagating the error through the memory hierarchy
3. Refactor the instruction fault handling to squash the instruction and pass the exception through the pipeline to the mem stage
4. Ensure mtval is updated with the correct address on an instruction fault