### PR TITLE
fix: Incorrect config integer comparison form

### DIFF
--- a/scripts/config_core.py
+++ b/scripts/config_core.py
@@ -152,10 +152,10 @@ def create_include(config):
       if uarch_param not in free_params and not isinstance(uarch_params[uarch_param], int):
         err = 'Illegal configuration of incorrect type for ' + uarch_param
         sys.exit(err)
-      if uarch_params['dcache_size'] % (uarch_params['dcache_block_size'] * uarch_params['dcache_assoc']) is not 0:
+      if uarch_params['dcache_size'] % (uarch_params['dcache_block_size'] * uarch_params['dcache_assoc']) != 0:
         err = 'Invalid dcache_size. Not divisible by block_size * assoc.'
         sys.exit(err)
-      if uarch_params['icache_size'] % (uarch_params['icache_block_size'] * uarch_params['icache_assoc']) is not 0:
+      if uarch_params['icache_size'] % (uarch_params['icache_block_size'] * uarch_params['icache_assoc']) != 0:
         err = 'Invalid icache_size. Not divisible by block_size * assoc.'
         sys.exit(err)
     elif uarch_params[uarch_param] not in UARCH_PARAMS[uarch_param]:


### PR DESCRIPTION
Don't compare integer values with `is`

`is` compares pointers ("object IDs"), `!=` compares values