### PR TITLE
build: Disable verilator error for ENUMVALUE

### DIFF
--- a/source_code/pipelines/stage3/source/stage3_execute_stage.sv
+++ b/source_code/pipelines/stage3/source/stage3_execute_stage.sv
@@ -237,7 +237,9 @@ module stage3_execute_stage (
     // TODO: NEW
     always_ff @(posedge CLK, negedge nRST) begin
         if(!nRST) begin
+            /*verilator lint_off ENUMVALUE*/
             ex_mem_if.ex_mem_reg <= '{default: '0};
+            /*verilator lint_on ENUMVALUE*/
         end else begin
             // TODO: This register is ~180b. Not awful, but can it be smaller?
             // PS: Does it even matter? Synth. tools may be able to merge regs.
@@ -298,7 +300,9 @@ module stage3_execute_stage (
                 ex_mem_if.ex_mem_reg.tracker_signals.imm_U  <= cu_if.imm_U;
 
             end else if(hazard_if.ex_mem_flush && !hazard_if.ex_mem_stall) begin
+                /*verilator lint_off ENUMVALUE*/
                 ex_mem_if.ex_mem_reg <= '{default: '0};
+                /*verilator lint_on ENUMVALUE*/
             end
             // else: retain state
         end


### PR DESCRIPTION
For when you get around to updating verilator