### PR TITLE
rv32m: fix bug where core would hang if first rv32m instruction is 0*0.

### DIFF
--- a/source_code/pipelines/stage3/source/stage3_execute_stage.sv
+++ b/source_code/pipelines/stage3/source/stage3_execute_stage.sv
@@ -105,7 +105,7 @@ module stage3_execute_stage (
     /******************
     * Functional Units
     *******************/
-    logic rv32m_busy;
+    logic rv32m_done;
     word_t rv32m_out;
     word_t ex_out;
     word_t rs1_post_fwd, rs2_post_fwd;
@@ -121,7 +121,7 @@ module stage3_execute_stage (
         .operation(cu_if.rv32m_control.op), // TODO: Better way?
         .rv32m_a(rs1_post_fwd), // All RV32M are reg-reg, so just feed post-fwd regs
         .rv32m_b(rs2_post_fwd),
-        .rv32m_busy,
+        .rv32m_done,
         .rv32m_out
     );
 
@@ -230,7 +230,7 @@ module stage3_execute_stage (
     assign fw_if.rs2_e = rf_if.rs2;
 
     assign hazard_if.pc_e = fetch_ex_if.fetch_ex_reg.pc;
-    assign hazard_if.ex_busy = (rv32m_busy && cu_if.rv32m_control.select); // Add & conditions here for other FUs that can stall
+    assign hazard_if.ex_busy = (!rv32m_done && cu_if.rv32m_control.select); // Add & conditions here for other FUs that can stall
     assign hazard_if.valid_e = fetch_ex_if.fetch_ex_reg.valid;
 
 

--- a/source_code/rv32m/flex_counter_mul.sv
+++ b/source_code/rv32m/flex_counter_mul.sv
@@ -23,11 +23,7 @@ module flex_counter_mul #(
     end
 
     always_comb begin
-        if (clear == 1) next_flag = 0;
-        else if (count_enable == 0) next_flag = rollover_flag;
-        else if (count_out == (rollover_val - 1) & clear == 1'b0) next_flag = 1;
-        else next_flag = 0;
-
+        next_flag = count_out == (rollover_val - 1);
 
         if (clear) next_count = 0;
         else if (count_enable) begin

--- a/source_code/rv32m/pp_mul32.sv
+++ b/source_code/rv32m/pp_mul32.sv
@@ -275,7 +275,7 @@ module pp_mul32 (
     flex_counter_mul #(2) FC (
         .clk(CLK),
         .n_rst(nRST),
-        .clear(start),
+        .clear(start && state == IDLE),
         .count_enable(count_ena),
         .rollover_val(2'd2),
         .count_out(count),
@@ -309,19 +309,6 @@ module pp_mul32 (
     end
 
     always_comb begin
-        /*
-        next_state = state;
-        case (state)
-            IDLE: begin
-                if (start)
-                    next_state = START;
-            end
-            START: begin
-                if (finished)
-                    next_state = IDLE;
-            end
-        endcase
-        */
         next_state = state;
         if (state == IDLE && start) begin
             next_state = START;
@@ -333,15 +320,7 @@ module pp_mul32 (
     end
 
     always_comb begin
-        count_ena = 0;
-        case (state)
-            IDLE: begin
-                count_ena = 0;
-            end
-            START: begin
-                count_ena = ~finished;
-            end
-        endcase
+        count_ena = state == START && !finished;
     end
 
 endmodule

--- a/source_code/rv32m/rv32m_disabled.sv
+++ b/source_code/rv32m/rv32m_disabled.sv
@@ -6,11 +6,11 @@ module rv32m_disabled(
     input rv32m_pkg::rv32m_op_t operation,
     input [31:0] rv32m_a,
     input [31:0] rv32m_b,
-    output rv32m_busy,
+    output rv32m_done,
     output logic [31:0] rv32m_out
 );
 
-    assign rv32m_busy = 1'b0;
+    assign rv32m_done = 1'b1;
     assign rv32m_out = 32'b0;
 
 endmodule

--- a/source_code/rv32m/rv32m_enabled.sv
+++ b/source_code/rv32m/rv32m_enabled.sv
@@ -30,7 +30,7 @@ module rv32m_enabled (
     input rv32m_pkg::rv32m_op_t operation,
     input [31:0] rv32m_a,
     input [31:0] rv32m_b,
-    output logic rv32m_busy,
+    output logic rv32m_done,
     output logic [31:0] rv32m_out
 );
 
@@ -73,7 +73,7 @@ module rv32m_enabled (
             op_b_save      <= '0;
             //is_signed_save <= '0;
             operation_save <= MUL;
-        end else if (operand_diff) begin
+        end else if (rv32m_start && rv32m_done) begin
             op_a_save      <= rv32m_a;
             op_b_save      <= rv32m_b;
             //is_signed_save <= is_signed_curr;
@@ -151,38 +151,38 @@ module rv32m_enabled (
             // take at least 1 extra cycle if we aren't reusing a value.
             casez(operation)
                 MUL: begin
-                    rv32m_busy = operand_diff || !mul_finished;
+                    rv32m_done = !operand_diff || mul_finished;
                     rv32m_out  = product[WORD_SIZE-1:0];
                 end
 
                 MULH, MULHU, MULHSU: begin
-                    rv32m_busy = operand_diff || !mul_finished;
+                    rv32m_done = !operand_diff || mul_finished;
                     rv32m_out  = product[(WORD_SIZE*2)-1 : WORD_SIZE];
                 end
 
                 // TODO: Is there a better way to decode this? Lots of repetition.
                 DIV: begin
-                    rv32m_busy = operand_diff || (!div_finished && !div_zero && !overflow);
+                    rv32m_done = !operand_diff || div_finished || div_zero || overflow;
                     rv32m_out  = div_zero ? 32'hffff_ffff : (overflow ? 32'h8000_0000 : quotient);
                 end
 
                 DIVU: begin
-                    rv32m_busy = operand_diff || (!div_finished && !div_zero && !overflow);
+                    rv32m_done = !operand_diff || div_finished || div_zero || overflow;
                     rv32m_out  = div_zero ? 32'h7fff_ffff : (overflow ? 32'h8000_0000 : quotient);
                 end
 
                 REM, REMU: begin
-                    rv32m_busy = operand_diff || (!div_finished && !div_zero && !overflow);
+                    rv32m_done = !operand_diff || div_finished || div_zero || overflow;
                     rv32m_out  = div_zero ? dividend : (overflow ? 32'h0000_0000 : remainder);
                 end
 
                 default: begin
-                    rv32m_busy = 1'b0;
+                    rv32m_done = 1'b1;
                     rv32m_out = 32'b0; // TODO: Should this return BAD3?
                 end
             endcase
         end else begin
-            rv32m_busy = 1'b0;
+            rv32m_done = 1'b1;
             rv32m_out = 32'b0;
         end
     end

--- a/source_code/rv32m/rv32m_wrapper.sv
+++ b/source_code/rv32m/rv32m_wrapper.sv
@@ -7,7 +7,7 @@ module rv32m_wrapper(
     input rv32m_pkg::rv32m_op_t operation,
     input [31:0] rv32m_a,
     input [31:0] rv32m_b,
-    output rv32m_busy,
+    output rv32m_done,
     output logic [31:0] rv32m_out
 );
     import rv32m_pkg::*;

--- a/verification/self-tests/RV32M/mul_bug.S
+++ b/verification/self-tests/RV32M/mul_bug.S
@@ -1,0 +1,29 @@
+#*****************************************************************************
+# mul_bug.S
+#-----------------------------------------------------------------------------
+#
+# The multiplier used to have a bug where if the first multiply was 0 * 0, then
+# the core would hang due to bad logic. This test adds coverage against that bug.
+# This does not affect mul{h, hsu, hu} because the saved operation on reset is
+# MUL, so operand_diff would be high for those. This does not affect div or rem
+# because divide by 0 is a caught error.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV32U
+RVTEST_CODE_BEGIN
+
+  TEST_RR_OP(1,  mul, 0x00000000, 0x00000000, 0x00000000 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END


### PR DESCRIPTION
Changed interface between control unit and rv32m function units to use an edge triggered `done` signal instead of a level high `busy` signal. This allows for detection of the corner case where the first mul/div operation is `mul rd, rs1, rs2` where `rs1` and `rs2` are both 0. This used to cause a hang in the execute stage since the operands weren't different and the multiplier was never started. Now, with a `done` signal, we can finish as soon as we see the operands are the same, even in this corner case.

See commit message for all the details.

A small benefit of this change is that divisions now have 1 less cycle of overhead.
Before:
![Screenshot 2023-12-05 at 9 25 04 PM](https://github.com/Purdue-SoCET/RISCVBusiness/assets/17111639/a9866f26-a5eb-4ea1-a21b-40a737e1ee6d)
After:
![Screenshot 2023-12-05 at 9 24 28 PM](https://github.com/Purdue-SoCET/RISCVBusiness/assets/17111639/ea02d12b-69f2-4f9b-9406-35a47f505bba)
