### PR TITLE
verification: add test coverage for interrupt fired during branch bug

### DIFF
--- a/verification/interrupts-exceptions/int_during_ret.c
+++ b/verification/interrupts-exceptions/int_during_ret.c
@@ -1,0 +1,62 @@
+// This test adds coverage for proper mepc selection when an interrupt is
+// triggered on a branching instruction.This test case heavily relies on the
+// timing of the interrupt being fired, and the return instruction being
+// committed.When making changes to things which change the latency of the core
+// (i.e.cache, pipeline, etc), ensure that this test continues to cover
+// this bug by manually inspecting the waveforms.
+// The general steps for ensuring that this test is up to date is to:
+//     1) Compile and run this test
+//     2) False negatives are unlikely, but false positives can be common due to how subtle this bug
+//     is. Always double check that the test is actually passing by inspecting the waveforms.
+//     3) Open up the waveforms and look for the intr signal in the prv_pipe_if. Ensure that it
+//     lines up with pc_m in the hazard unit being the address of the first `ret` instruction in
+//     `foo`.
+//     4) If it does not line up, adjust the value of `mtimecmp` in `main` to trigger the interrupt
+//     earlier or later depending on what is needed.
+
+#include "utility.h"
+#include <stdint.h>
+
+extern int flag;
+
+volatile uint32_t *mtime = (uint32_t *)MTIME_ADDR;
+volatile uint32_t *mtimecmp = (uint32_t *)MTIMECMP_ADDR;
+volatile uint32_t *mtimecmph = (uint32_t *)MTIMECMPH_ADDR;
+volatile uint32_t *msip = (uint32_t *)MSIP_ADDR;
+volatile uint32_t *ext_trigger = (uint32_t *)EXT_ADDR_SET;
+volatile uint32_t *ext_clear = (uint32_t *)EXT_ADDR_CLEAR;
+
+void __attribute__((interrupt)) __attribute__((aligned(4))) handler() {
+    uint32_t mie_value = 0x00;
+    asm volatile("csrw mie, %0" : : "r"(mie_value));
+    print("Made it to handler!\n");
+    flag = 1;
+}
+
+void __attribute__((noinline)) __attribute__((naked)) foo() {
+    asm("li t1, 0xFF\n"
+        "add zero, zero, zero\n"
+        "add zero, zero, zero\n"
+        "add zero, zero, zero\n"
+        "add zero, zero, zero\n"
+        "ret\n"
+        "sw t1, %0\n"
+        "ret\n"
+        :
+        : "A"(flag));
+}
+
+int main() {
+    // set mtimecmp away so interrupt doesn't fire immediately
+    *mtimecmph = 0x00;
+    *mtimecmp = 0x148;
+
+    uint32_t mstatus_value = 0x8;
+    uint32_t mie_value = 0x80;
+    uint32_t mtvec_value = (uint32_t)handler;
+    asm volatile("csrw mstatus, %0" : : "r"(mstatus_value));
+    asm volatile("csrw mie, %0" : : "r"(mie_value));
+    asm volatile("csrw mtvec, %0" : : "r"(mtvec_value));
+
+    foo();
+}


### PR DESCRIPTION
Adds coverage for ensuring that an interrupt fired during a branching instruction returns to the branching instruction instead of the instruction after. To test use `./build_all.py` in the `verification/interrupts-exceptions` directory, copy `int_during_ret.bin` to `meminit.bin`, then run `Vtop_core`. The test should pass.

To see the test fail, patch the hazard unit with this diff and run it again:
```diff
diff --git a/source_code/pipelines/stage3/source/stage3_hazard_unit.sv b/source_code/pipelines/stage3/source/stage3_hazard_unit.sv
index b6635717..dc82f33a 100644
--- a/source_code/pipelines/stage3/source/stage3_hazard_unit.sv
+++ b/source_code/pipelines/stage3/source/stage3_hazard_unit.sv
@@ -100,7 +100,7 @@ module stage3_hazard_unit (
     assign hazard_if.rollback = (hazard_if.ifence && !hazard_if.fence_stall); // TODO: more cases for CSRs that affect I-fetch (PMA/PMP registers)

     // EPC priority logic
-    assign epc = hazard_if.valid_m && (!intr || branch_jump) ? hazard_if.pc_m :
+    assign epc = hazard_if.valid_m && !intr ? hazard_if.pc_m :
                 (hazard_if.valid_e ? hazard_if.pc_e : hazard_if.pc_f);

     /* Send Exception notifications to Prv Block */

```