### PR TITLE
Conditional Instructions Extension

### DIFF
--- a/RISCVBusiness.core
+++ b/RISCVBusiness.core
@@ -53,7 +53,7 @@ filesets:
             
     verilator_tb:
         files:
-            - tb_core.cc : {fileType: cppSource} 
+            - tb_core.cc : {file_type: cppSource}
         file_type: systemVerilogSource
 
     no_memory_tb:

--- a/RISCVBusiness.core
+++ b/RISCVBusiness.core
@@ -19,6 +19,7 @@ filesets:
             - "socet:riscv:rv32c"
             - "socet:riscv:rv32m"
             - "socet:riscv:rv32b"
+            - "socet:riscv:rv32zc"
         files:
             - source_code/branch_predictors/branch_predictor_wrapper.sv
             - source_code/branch_predictors/nottaken_predictor/nottaken_predictor.sv

--- a/run_tests_verilator.py
+++ b/run_tests_verilator.py
@@ -219,7 +219,7 @@ def compile_asm(filepath: Type[pathlib.Path], outpath: Type[pathlib.Path],\
 def run_sim(top_level: str, logger: Type[logging.Logger]) -> None:
 
     # TODO: Assuming simulator already built
-    cmd_arr = ['./rvb_out/sim-verilator/Vtop_core', 'meminit.bin']
+    cmd_arr = ['./rvb_out/socet_riscv_RISCVBusiness_0.1.1/sim-verilator/Vtop_core', 'meminit.bin']
     res = subprocess.run(cmd_arr, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
 
     #config_cmd_arr = ["waf", "configure", "--top_level=" + top_level]

--- a/scripts/config_core.py
+++ b/scripts/config_core.py
@@ -109,7 +109,7 @@ UARCH_PARAMS = \
 RISC_MGMT_PARAMS = \
   {
     # Valid standard extensions
-    'standard_extensions' : {'name' : ['rv32m', 'rv32a', 'rv32b']},
+    'standard_extensions' : {'name' : ['rv32m', 'rv32a', 'rv32b', 'rv32zc']},
     # Valid nonstandard extensions
     'nonstandard_extensions' : {'encoding' : ['R_TYPE', 'M_TYPE', 'J_TYPE', 'BR_TYPE', 'G_TYPE']}
   }

--- a/source_code/include/control_unit_if.vh
+++ b/source_code/include/control_unit_if.vh
@@ -33,6 +33,7 @@ interface control_unit_if;
   import rv32a_pkg::*;
   import rv32m_pkg::*;
   import rv32b_pkg::*;
+  import rv32zc_pkg::*;
 
   logic dwen, dren, j_sel, branch, jump, ex_pc_sel, imm_shamt_sel, halt, wen, ifence, wfi;
   aluop_t alu_op;
@@ -59,6 +60,7 @@ interface control_unit_if;
   rv32m_decode_t rv32m_control;
   rv32b_decode_t rv32b_control;
   rv32a_decode_t rv32a_control;
+  rv32zc_decode_t rv32zc_control;
 
   modport control_unit(
     input instr,
@@ -67,8 +69,8 @@ interface control_unit_if;
     imm_I, imm_S, imm_SB, imm_UJ, imm_U, imm_shamt_sel, alu_op,
     opcode, halt, wen, fault_insn, illegal_insn, ret_insn, breakpoint,
     ecall_insn, csr_swap, csr_set, csr_clr, csr_imm, csr_rw_valid,
-    csr_addr, zimm, ifence, wfi, rd, rv32m_control, rv32a_control,
-    rv32b_control, reserve, exclusive
+    csr_addr, zimm, ifence, wfi, rd, rv32m_control, rv32a_control, 
+    rv32b_control, rv32zc_control, reserve, exclusive,  
   );
 
 endinterface

--- a/source_code/include/control_unit_if.vh
+++ b/source_code/include/control_unit_if.vh
@@ -69,9 +69,8 @@ interface control_unit_if;
     imm_I, imm_S, imm_SB, imm_UJ, imm_U, imm_shamt_sel, alu_op,
     opcode, halt, wen, fault_insn, illegal_insn, ret_insn, breakpoint,
     ecall_insn, csr_swap, csr_set, csr_clr, csr_imm, csr_rw_valid,
-    csr_addr, zimm, ifence, wfi, rd, rv32m_control, rv32a_control, 
-    rv32b_control, rv32zc_control, reserve, exclusive,  
+    csr_addr, zimm, ifence, wfi, rd, rv32m_control, rv32a_control,
+    rv32b_control, rv32zc_control, reserve, exclusive
   );
-
 endinterface
 `endif

--- a/source_code/packages/riscv_packages.core
+++ b/source_code/packages/riscv_packages.core
@@ -13,10 +13,7 @@ filesets:
             - rv32m_pkg.sv
             - rv32a_pkg.sv
             - rv32b_pkg.sv
-            #- risc_mgmt/crc32_pkg.sv
-            #- risc_mgmt/template_pkg.sv
-            #- risc_mgmt/test_pkg.sv
-            #- risc_mgmt/rv32m_pkg.sv
+            - rv32zc_pkg.sv
         file_type: systemVerilogSource
 
 targets:

--- a/source_code/packages/rv32zc_pkg.sv
+++ b/source_code/packages/rv32zc_pkg.sv
@@ -1,0 +1,47 @@
+/*
+*   Copyright 2024 Purdue University
+*
+*   Licensed under the Apache License, Version 2.0 (the "License");
+*   you may not use this file except in compliance with the License.
+*   You may obtain a copy of the License at
+*
+*       http://www.apache.org/licenses/LICENSE-2.0
+*
+*   Unless required by applicable law or agreed to in writing, software
+*   distributed under the License is distributed on an "AS IS" BASIS,
+*   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*   See the License for the specific language governing permissions and
+*   limitations under the License.
+*
+*
+*   Filename:     rv32zc_pkg.sv
+*
+*   Created by:   Akshath Raghav R
+*   Email:        araviki@purdue.edu
+*   Date Created: 02/06/2024
+*   Description:  Types for the ZiCond 'Conditional Expression' Extension
+*/
+
+package rv32zc_pkg;
+
+    typedef struct packed {
+        logic [6:0] opcode_minor;
+        logic [4:0] rs2;
+        logic [4:0] rs1;
+        logic [2:0] funct;
+        logic [4:0] rd;
+        logic [6:0] opcode_major;
+    } rv32zc_insn_t;
+
+    typedef enum logic [2:0] {
+        NEZ, 
+        EQZ
+    } rv32zc_op_t /*verilator public*/;
+
+    typedef struct packed {
+        logic select;
+        rv32zc_op_t op;
+    } rv32zc_decode_t;
+
+
+endpackage

--- a/source_code/pipelines/stage3/source/stage3_execute_stage.sv
+++ b/source_code/pipelines/stage3/source/stage3_execute_stage.sv
@@ -105,8 +105,10 @@ module stage3_execute_stage (
     *******************/
     logic rv32m_done;
     logic rv32b_done;
+    logic rv32zc_done;
     word_t rv32m_out;
     word_t rv32b_out;
+    word_t rv32zc_out;
     word_t ex_out;
     word_t rs1_post_fwd, rs2_post_fwd;
 
@@ -131,6 +133,14 @@ module stage3_execute_stage (
         .operation(cu_if.rv32b_control),
         .rv32b_done(rv32b_done),
         .rv32b_out(rv32b_out)
+    );
+
+    rv32zc_wrapper RV32ZC_FU(
+        .rv32zc_a(alu_if.port_a),
+        .rv32zc_b(alu_if.port_b),
+        .operation(cu_if.rv32zc_control),
+        .rv32zc_done(rv32zc_done),
+        .rv32zc_out(rv32zc_out)
     );
 
     // Forwarding
@@ -196,6 +206,8 @@ module stage3_execute_stage (
             ex_out = rv32m_out;
         end else if(cu_if.rv32b_control.select) begin
             ex_out = rv32b_out;
+        end else if(cu_if.rv32zc_control.select) begin
+            ex_out = rv32zc_out;
         end else begin
             ex_out = alu_if.port_out;
         end

--- a/source_code/rv32zc/rv32zc.core
+++ b/source_code/rv32zc/rv32zc.core
@@ -1,0 +1,40 @@
+CAPI=2:
+name: socet:riscv:rv32zc:0.1.0
+description: RV32ZC Extension for RISCVBusiness
+
+filesets:
+    handler:
+        depend:
+            - "socet:riscv:riscv_include"
+            - "socet:riscv:packages"
+        files:
+            - rv32zc_handler.sv
+            - test_rv32zc_handler.cc
+        file_type: systemVerilogSource
+
+    rtl:
+        depend:
+            - "socet:riscv:riscv_include"
+            - "socet:riscv:packages"
+        files:
+            - rv32zc_handler.sv
+            - rv32zc_decode.sv
+            - rv32zc_disabled.sv
+            - rv32zc_enabled.sv
+            - rv32zc_wrapper.sv
+        file_type: systemVerilogSource
+    
+targets:
+    default: &default
+        filesets:
+            - rtl
+        toplevel: rv32zc_wrapper
+    
+    handler_tb:
+        filesets:
+            - handler
+        toplevel: rv32zc_handler
+        tools:
+            verilator:
+                verilator_options: ["-Wno-SYMRSVDWORD", "-CFLAGS -std=c++20", "-Wno-lint", "--trace", "--trace-fst", "--trace-structs"]
+

--- a/source_code/rv32zc/rv32zc_decode.sv
+++ b/source_code/rv32zc/rv32zc_decode.sv
@@ -1,0 +1,35 @@
+module rv32zc_decode(
+    input logic [31:0] insn,
+    output logic claim,
+    output rv32zc_pkg::rv32zc_decode_t rv32zc_control
+);
+    import rv32i_types_pkg::*;
+    import rv32zc_pkg::*;
+
+    localparam logic [6:0] RV32ZC_OPCODE = 7'b0110011;
+    localparam logic [6:0] RV32ZC_OPCODE_MINOR = 7'b0000111;
+
+    rv32zc_insn_t insn_split;
+    rv32zc_op_t operation;
+
+    assign insn_split = rv32zc_insn_t'(insn);
+
+    always_comb begin
+        claim = 1'b1;
+        operation = EQZ;
+
+        if (insn_split.opcode_major == REGREG && insn_split.opcode_minor == RV32ZC_OPCODE_MINOR) begin 
+            casez(insn_split.funct)  
+                3'b111  : operation = NEZ; 
+                3'b101  : operation = EQZ; 
+                default: claim = 1'b0; 
+            endcase
+        end else begin 
+            claim = 1'b0; 
+        end
+
+    end
+
+    assign rv32zc_control = {claim, operation};
+
+endmodule

--- a/source_code/rv32zc/rv32zc_disabled.sv
+++ b/source_code/rv32zc/rv32zc_disabled.sv
@@ -1,0 +1,10 @@
+module rv32zc_disabled(
+    input rv32zc_pkg::rv32zc_op_t operation,
+    input [31:0] rv32zc_a,
+    input [31:0] rv32zc_b,
+    output logic rv32zc_done,
+    output logic [31:0] rv32zc_out
+);
+    assign rv32zc_done = 1'b1;
+    assign rv32zc_out = 32'b0;
+endmodule

--- a/source_code/rv32zc/rv32zc_enabled.sv
+++ b/source_code/rv32zc/rv32zc_enabled.sv
@@ -1,0 +1,22 @@
+`include "component_selection_defines.vh"
+
+module rv32zc_enabled(
+    input rv32zc_pkg::rv32zc_op_t operation,
+    input [31:0] rv32zc_a,
+    input [31:0] rv32zc_b,
+    output logic rv32zc_done,
+    output logic [31:0] rv32zc_out
+);
+
+    import rv32zc_pkg::*;
+
+    rv32zc_handler RV32ZCHANDLER(
+        .a(rv32zc_a),
+        .b(rv32zc_b),
+        .aluop(operation),
+        .y(rv32zc_out)
+    );
+
+    assign rv32zc_done = 1;
+
+endmodule

--- a/source_code/rv32zc/rv32zc_handler.sv
+++ b/source_code/rv32zc/rv32zc_handler.sv
@@ -1,0 +1,23 @@
+module rv32zc_handler(
+    input [31:0] a,
+    input [31:0] b,
+    input rv32zc_pkg::rv32zc_op_t aluop,
+    output logic [31:0] y
+);
+   
+    import rv32zc_pkg::*;
+    logic [31:0] rd_temp;
+
+    always_comb begin
+        casez(aluop)
+            NEZ: begin 
+                y = (b != 0) ? 0 : a;
+            end 
+            EQZ: begin 
+                y = (b == 0) ? 0 : a;
+            end 
+        endcase
+    end
+
+
+endmodule

--- a/source_code/rv32zc/rv32zc_wrapper.sv
+++ b/source_code/rv32zc/rv32zc_wrapper.sv
@@ -1,0 +1,17 @@
+`include "component_selection_defines.vh"
+
+module rv32zc_wrapper(
+    input rv32zc_pkg::rv32zc_op_t operation,
+    input [31:0] rv32zc_a,
+    input [31:0] rv32zc_b,
+    output logic rv32zc_done,
+    output logic [31:0] rv32zc_out
+);
+
+    `ifdef RV32ZC_SUPPORTED
+        rv32zc_enabled RV32ZC(.*);
+    `else
+        rv32zc_disabled RV32ZC(.*);
+    `endif
+
+endmodule

--- a/source_code/rv32zc/test_rv32zc_handler.cc
+++ b/source_code/rv32zc/test_rv32zc_handler.cc
@@ -1,0 +1,93 @@
+#include <iostream>
+#include <iomanip>
+#include <random>
+#include <functional>
+#include <bit>
+#include <bitset>
+
+#include "verilated.h"
+#include "verilated_fst_c.h"
+#include "Vrv32zc_handler.h"
+#include "Vrv32zc_handler_rv32zc_pkg.h"
+
+#define DEFAULT_CASES 10000
+
+
+uint64_t sim_time = 0;
+
+uint64_t test_count = 0;
+uint64_t pass_count = 0;
+
+static inline void check(uint32_t expected, uint32_t actual, uint32_t a, uint32_t b) {
+    test_count++;
+    if(expected == actual) {
+        pass_count++;
+    } else {
+        std::cout << std::dec << "FAIL " << test_count << " @ T=" << sim_time << std::hex 
+            << " EXP: " << expected << " ACT: " << actual
+            << "; A = " << a << " B = " << b << std::endl;
+        
+    }
+}
+
+void tick(Vrv32zc_handler& dut, VerilatedFstC& trace) {
+    dut.eval(); 
+    trace.dump(sim_time++);
+    dut.eval();
+    trace.dump(sim_time++);
+}
+
+
+int main(int argc, char **argv) {
+
+    long num_cases = DEFAULT_CASES;
+    if(argc == 2) {
+        num_cases = atol(argv[1]);
+    }
+    std::cout << "Running " << num_cases << " cases." << std::endl;
+
+    // RNG
+    std::random_device dev;
+    std::mt19937 rng(dev());
+    std::uniform_int_distribution<std::mt19937::result_type> dist(0, UINT32_MAX);
+
+    Vrv32zc_handler dut;
+    VerilatedFstC m_trace;
+    Verilated::traceEverOn(true);
+    dut.trace(&m_trace, 5);
+
+    // Test cases
+    typedef uint32_t u32;
+
+    struct test_vector_t {
+        Vrv32zc_handler_rv32zc_pkg::rv32zc_op_t aluop;
+        std::function<uint32_t(u32, u32)> eval;
+    };
+
+    static const test_vector_t ops[] = {
+        {Vrv32zc_handler_rv32zc_pkg::EQZ, [](u32 a, u32 b) -> uint32_t { 
+            return (b == 0) ? 0 : a; 
+        }},
+        {Vrv32zc_handler_rv32zc_pkg::NEZ, [](u32 a, u32 b) -> uint32_t { 
+            return (b != 0) ? 0 : a; 
+        }}
+    };
+
+    constexpr auto array_size = sizeof(ops) / sizeof(*ops);
+    for (int i = 0; i < array_size; i++) { // SH{N}
+        dut.aluop = ops[i].aluop;
+        for (int j = 0; j < num_cases; j++) {
+            uint32_t a = dist(rng);
+            uint32_t b = dist(rng);
+            uint32_t expected = ops[i].eval(a, b);
+            dut.a = a;
+            dut.b = b;
+            tick(dut, m_trace);
+            check(expected, dut.y, a, b);
+        }
+    }
+
+    std::cout << std::dec << "Passed " << pass_count << " / " << test_count << " tests." << std::endl;
+
+    return 0;
+}

--- a/source_code/tb/tb_cache_coherence_stress/cache_coherence_stress.core
+++ b/source_code/tb/tb_cache_coherence_stress/cache_coherence_stress.core
@@ -13,7 +13,7 @@ filesets:
     verilator_tb:
         files:
             - cache_stress_wrapper.sv
-            - tb_cache_stress_test.cc : { fileType: cppSource }
+            - tb_cache_stress_test.cc : { file_type: cppSource }
         file_type: systemVerilogSource
 
 targets:

--- a/verification/self-tests/RV32ZC/add.S
+++ b/verification/self-tests/RV32ZC/add.S
@@ -1,0 +1,54 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# add.S
+#*****************************************************************************
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV32U
+RVTEST_CODE_BEGIN
+
+  TEST_CASE(1, x14, 0x2, \
+    li x1, 0x1; \
+    li x2, 0x1; \
+    li x3, 0x0; \
+    czero.nez x14, x2, x3; \
+    add x14, x1, x14; \
+  )
+
+  TEST_CASE(2, x14, 0x1, \
+    li x1, 0x1; \
+    li x2, 0x1; \
+    li x3, 0x1; \
+    czero.nez x14, x2, x3; \
+    add x14, x1, x14; \
+  )
+
+  TEST_CASE(3, x14, 0x1, \
+    li x1, 0x1; \
+    li x2, 0x0; \
+    li x3, 0x0; \
+    czero.eqz x14, x2, x3; \
+    add x14, x1, x14; \
+  )
+
+  TEST_CASE(4, x14, 0x2, \
+    li x1, 0x1; \
+    li x2, 0x1; \
+    li x3, 0x1; \
+    czero.eqz x14, x2, x3; \
+    add x14, x1, x14; \
+  )
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/verification/self-tests/RV32ZC/and.S
+++ b/verification/self-tests/RV32ZC/and.S
@@ -1,0 +1,41 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# and.S
+#*****************************************************************************
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV32U
+RVTEST_CODE_BEGIN
+
+  TEST_CASE(1, x14, 0x8, \
+    li x1, 0xC; \
+    li x2, 0x19; \
+    li x3, 0x0; \
+    and x14, x1, x2; \
+    czero.eqz x15, x1, x3; \
+    or x14, x14, x15; \
+  )
+
+  TEST_CASE(2, x14, 0x8, \
+    li x1, 0xC; \
+    li x2, 0x19; \
+    li x3, 0x1; \
+    and x14, x1, x2; \
+    czero.nez x15, x1, x3; \
+    or x14, x14, x15; \
+  )
+
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/verification/self-tests/RV32ZC/compare.S
+++ b/verification/self-tests/RV32ZC/compare.S
@@ -1,0 +1,68 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# add.S
+#-----------------------------------------------------------------------------
+#
+# Test add instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV32U
+RVTEST_CODE_BEGIN
+
+  # x5 will hold the value of larger/smaller value between x1/x2
+
+  TEST_CASE( 1, x5, 1, \
+    li x1, 3;       
+    li x2, 1; 
+    sub x3, x1, x2;
+    srli x4, x3, 31; 
+    czero.eqz x5, x1, x4; 
+    czero.nez x6, x2, x4; 
+    or x5, x5, x6;
+  )
+
+  TEST_CASE( 2, x5, 7, \
+    li x1, 7;       
+    li x2, 2; 
+    sub x3, x1, x2;
+    srli x4, x3, 31; 
+    czero.nez x5, x1, x4;
+    czero.eqz x6, x2, x4; 
+    or x5, x5, x6;
+  )
+
+  TEST_CASE( 3, x5, 5, \
+    li x1, 10;       
+    li x2, 5; 
+    sub x3, x1, x2;
+    srli x4, x3, 31; 
+    czero.eqz x5, x1, x4; 
+    czero.nez x6, x2, x4; 
+    or x5, x5, x6;
+  )
+
+  TEST_CASE( 4, x5, 9, \
+    li x1, 9;       
+    li x2, 1; 
+    sub x3, x1, x2;
+    srli x4, x3, 31; 
+    czero.nez x5, x1, x4;
+    czero.eqz x6, x2, x4; 
+    or x5, x5, x6;
+  )
+
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/verification/self-tests/RV32ZC/or.S
+++ b/verification/self-tests/RV32ZC/or.S
@@ -1,0 +1,54 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# or.S
+#*****************************************************************************
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV32U
+RVTEST_CODE_BEGIN
+
+  TEST_CASE( 1, x14, 0x0, \
+    li x1, 0x0; \
+    li x2, 0x1; \
+    li x3, 0x0; \
+    czero.eqz x14, x2, x3; \
+    or x14, x1, x14; \
+  )
+  
+  TEST_CASE( 2, x14, 0x1, \
+    li x1, 0x0; \
+    li x2, 0x1; \
+    li x3, 0x1; \
+    czero.eqz x14, x2, x3; \
+    or x14, x1, x14; \
+  )
+
+  TEST_CASE( 3, x14, 0x0, \
+    li x1, 0x0; \
+    li x2, 0x1; \
+    li x3, 0x1; \
+    czero.nez x14, x2, x3; \
+    or x14, x1, x14; \
+  )
+
+  TEST_CASE( 4, x14, 0x1, \
+    li x1, 0x0; \
+    li x2, 0x1; \
+    li x3, 0x0; \
+    czero.nez x14, x2, x3; \
+    or x14, x1, x14; \
+  )
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/verification/self-tests/RV32ZC/sel.S
+++ b/verification/self-tests/RV32ZC/sel.S
@@ -1,0 +1,40 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# sel.S
+#*****************************************************************************
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV32U
+RVTEST_CODE_BEGIN
+
+  TEST_CASE(1, x14, 0x1, \
+    li x1, 0x1; \
+    li x2, 0x0; \
+    li x3, 0x0; \
+    czero.nez x14, x1, x3; \
+    czero.eqz x15, x2, x3; \
+    or x14, x14, x15; \
+  )
+
+  TEST_CASE(2, x14, 0x0, \
+    li x1, 0x0; \
+    li x2, 0x1; \
+    li x3, 0x1; \
+    czero.eqz x14, x1, x3; \
+    czero.nez x15, x2, x3; \
+    or x14, x14, x15; \
+  )
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/verification/self-tests/RV32ZC/sub.S
+++ b/verification/self-tests/RV32ZC/sub.S
@@ -1,0 +1,54 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# sub.S
+#*****************************************************************************
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV32U
+RVTEST_CODE_BEGIN
+
+  TEST_CASE(1, x14, 0x0, \
+    li x1, 0x1; \
+    li x2, 0x1; \
+    li x3, 0x0; \
+    czero.nez x14, x2, x3; \
+    sub x14, x1, x14; \
+  )
+
+  TEST_CASE(2, x14, 0x1, \
+    li x1, 0x1; \
+    li x2, 0x1; \
+    li x3, 0x1; \
+    czero.nez x14, x2, x3; \
+    sub x14, x1, x14; \
+  )
+
+  TEST_CASE(3, x14, 0x1, \
+    li x1, 0x1; \
+    li x2, 0x0; \
+    li x3, 0x0; \
+    czero.eqz x14, x2, x3; \
+    sub x14, x1, x14; \
+  )
+
+  TEST_CASE(4, x14, 0x0, \
+    li x1, 0x1; \
+    li x2, 0x1; \
+    li x3, 0x1; \
+    czero.eqz x14, x2, x3; \
+    sub x14, x1, x14; \
+  )
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/verification/self-tests/RV32ZC/xor.S
+++ b/verification/self-tests/RV32ZC/xor.S
@@ -1,0 +1,54 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# xor.S
+#*****************************************************************************
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV32U
+RVTEST_CODE_BEGIN
+
+  TEST_CASE(1, x14, 0x3, \
+    li x1, 0x1; \
+    li x2, 0x2; \
+    li x3, 0x0; \
+    czero.nez x14, x2, x3; \
+    xor x14, x1, x14; \
+  )
+
+  TEST_CASE(2, x14, 0x1, \
+    li x1, 0x1; \
+    li x2, 0x2; \
+    li x3, 0x1; \
+    czero.nez x14, x2, x3; \
+    xor x14, x1, x14; \
+  )
+
+  TEST_CASE(3, x14, 0x2, \
+    li x1, 0x2; \
+    li x2, 0x1; \
+    li x3, 0x0; \
+    czero.eqz x14, x2, x3; \
+    xor x14, x1, x14; \
+  )
+
+  TEST_CASE(4, x14, 0x3, \
+    li x1, 0x1; \
+    li x2, 0x2; \
+    li x3, 0x1; \
+    czero.eqz x14, x2, x3; \
+    xor x14, x1, x14; \
+  )
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END


### PR DESCRIPTION
### Zicond Extension

This PR implements the [Zicond](https://github.com/riscvarchive/riscv-zicond/blob/main/zicondops.adoc#instruction-sequences) extension (RV32ZC). 

The "Conditional" operations extension ... support conditional arithmetic and conditional-select/move operations .. philosophy.
The instructions follow the format for R-type instructions with 3 operands ... Using these instructions, branchless sequences can be implemented (typically in two-instruction sequences) without the need for instruction fusion .... provisions.

The following instructions comprise the Zicond extension:
* czero.eqz rd, rs1, rs2
* czero.nez rd, rs1, rs2

## Testing 

You can run the tests as follows: 
``
make run_tests_verilator TEST_FOLDER="./verification/self-tests/RV32ZC" ARCH="RV32ZC" MARCH="rv32i_zicsr_zifencei_zicond"
``

```
(.venv) bash-4.2$ make run_tests_verilator TEST_FOLDER="./verification/self-tests/RV32ZC" ARCH="RV32ZC" MARCH="rv32i_zicsr_zifencei_zicond"
./run_tests_verilator.sh ./verification/self-tests/RV32ZC RV32ZC rv32i_zicsr_zifencei_zicond
Running Main...
['/home/asicfab/a/socet167/araviki/RISCVBusiness/verification/self-tests/RV32ZC/add.S']
Running Strings: ['/home/asicfab/a/socet167/araviki/RISCVBusiness/verification/self-tests/RV32ZC/add.S']
-----------------------------
Running Test: add.S
    - Compiling...
    - Running Verilator...
    - Checking Results...
[PASSED]
Running Main...
['/home/asicfab/a/socet167/araviki/RISCVBusiness/verification/self-tests/RV32ZC/and.S']
Running Strings: ['/home/asicfab/a/socet167/araviki/RISCVBusiness/verification/self-tests/RV32ZC/and.S']
-----------------------------
Running Test: and.S
    - Compiling...
    - Running Verilator...
    - Checking Results...
[PASSED]
Running Main...
['/home/asicfab/a/socet167/araviki/RISCVBusiness/verification/self-tests/RV32ZC/or.S']
Running Strings: ['/home/asicfab/a/socet167/araviki/RISCVBusiness/verification/self-tests/RV32ZC/or.S']
-----------------------------
Running Test: or.S
    - Compiling...
    - Running Verilator...
    - Checking Results...
[PASSED]
Running Main...
['/home/asicfab/a/socet167/araviki/RISCVBusiness/verification/self-tests/RV32ZC/sel.S']
Running Strings: ['/home/asicfab/a/socet167/araviki/RISCVBusiness/verification/self-tests/RV32ZC/sel.S']
-----------------------------
Running Test: sel.S
    - Compiling...
    - Running Verilator...
    - Checking Results...
[PASSED]
Running Main...
['/home/asicfab/a/socet167/araviki/RISCVBusiness/verification/self-tests/RV32ZC/sub.S']
Running Strings: ['/home/asicfab/a/socet167/araviki/RISCVBusiness/verification/self-tests/RV32ZC/sub.S']
-----------------------------
Running Test: sub.S
    - Compiling...
    - Running Verilator...
    - Checking Results...
[PASSED]
Running Main...
['/home/asicfab/a/socet167/araviki/RISCVBusiness/verification/self-tests/RV32ZC/xor.S']
Running Strings: ['/home/asicfab/a/socet167/araviki/RISCVBusiness/verification/self-tests/RV32ZC/xor.S']
-----------------------------
Running Test: xor.S
    - Compiling...
    - Running Verilator...
    - Checking Results...
[PASSED]
```