### PR TITLE
priv unit: delay interrupt until `ex_mem_stall` goes low 

### DIFF
--- a/source_code/include/priv_1_12_internal_if.vh
+++ b/source_code/include/priv_1_12_internal_if.vh
@@ -78,6 +78,7 @@ interface priv_1_12_internal_if;
     logic insert_pc; // inform pipeline that we are changing the PC
     logic mret, sret; // returning from a trap instruction
     logic intr; // Did something trigger an interrupt or exception?
+    logic ex_mem_stall; // Is the pipe stalled?
 
     // Addresses and memory access info for memory protection
     logic [RAM_ADDR_SIZE-1:0] daddr, iaddr; // Address to check
@@ -103,7 +104,7 @@ interface priv_1_12_internal_if;
             clear_timer_int_u, clear_timer_int_s, clear_timer_int_m, clear_soft_int_u, clear_soft_int_s, clear_soft_int_m,
             clear_ext_int_u, clear_ext_int_s, clear_ext_int_m, mal_insn, fault_insn_access, illegal_insn, breakpoint, fault_l, mal_l, fault_s, mal_s,
             env_u, env_s, env_m, fault_insn_page, fault_load_page, fault_store_page, curr_mcause, curr_mepc, curr_mie, curr_mip, curr_mstatus, curr_mtval,
-            mret, sret, pipe_clear, ex_rmgmt, ex_rmgmt_cause, epc, curr_privilege_level,
+            mret, sret, pipe_clear, ex_rmgmt, ex_rmgmt_cause, epc, curr_privilege_level, ex_mem_stall,
         output inject_mcause, inject_mepc, inject_mip, inject_mstatus, inject_mtval,
             next_mcause, next_mepc, next_mie, next_mip, next_mstatus, next_mtval, intr
     );

--- a/source_code/include/prv_pipeline_if.vh
+++ b/source_code/include/prv_pipeline_if.vh
@@ -62,13 +62,14 @@ interface prv_pipeline_if();
   logic [RAM_ADDR_SIZE-1:0] iaddr, daddr;
   pma_accwidth_t d_acc_width, i_acc_width;
   logic prot_fault_s, prot_fault_l, prot_fault_i;
+  logic ex_mem_stall;
 
   modport hazard (
     input priv_pc, insert_pc, intr, prot_fault_s, prot_fault_l, prot_fault_i,
     output pipe_clear, ret, epc, fault_insn, mal_insn,
             illegal_insn, fault_l, mal_l, fault_s, mal_s,
             breakpoint, env, wfi, badaddr, wb_enable,
-            ex_rmgmt, ex_rmgmt_cause
+            ex_rmgmt, ex_rmgmt_cause, ex_mem_stall
   );
 
   modport pipe (
@@ -88,7 +89,7 @@ interface prv_pipeline_if();
           wdata, csr_addr, valid_write, wb_enable, instr,
           ex_rmgmt, ex_rmgmt_cause,
           daddr, iaddr, dren, dwen, iren,
-          d_acc_width, i_acc_width,
+          d_acc_width, i_acc_width, ex_mem_stall,
     output priv_pc, insert_pc, intr, rdata, invalid_priv_isn,
             prot_fault_s, prot_fault_l, prot_fault_i
   );

--- a/source_code/pipelines/stage3/source/stage3_hazard_unit.sv
+++ b/source_code/pipelines/stage3/source/stage3_hazard_unit.sv
@@ -119,6 +119,7 @@ module stage3_hazard_unit (
     assign prv_pipe_if.env = hazard_if.env;
     assign prv_pipe_if.wfi = hazard_if.wfi;
     assign prv_pipe_if.ex_rmgmt = 1'b0;//rm_if.exception;
+    assign prv_pipe_if.ex_mem_stall = hazard_if.ex_mem_stall;
 
     assign prv_pipe_if.ex_rmgmt_cause = '0;//rm_if.ex_cause;
     assign prv_pipe_if.epc = epc;

--- a/source_code/pipelines/stage3/source/stage3_hazard_unit.sv
+++ b/source_code/pipelines/stage3/source/stage3_hazard_unit.sv
@@ -165,13 +165,13 @@ module stage3_hazard_unit (
                                   || (hazard_if.if_ex_stall && !hazard_if.ex_mem_stall); // if_ex_stall covers mem_use stall condition
 
 
-    assign hazard_if.if_ex_stall  = hazard_if.ex_mem_stall // Stall this stage if next stage is stalled
+  assign hazard_if.if_ex_stall  = !intr && (hazard_if.ex_mem_stall // Stall this stage if next stage is stalled
                                   // || (wait_for_imem && !dmem_access) // ???
                                   //& (~ex_flush_hazard | e_ex_stage) // ???
                                   //|| rm_if.execute_stall //
                                   || (hazard_if.ex_busy && !ex_flush_hazard && !branch_jump) // Ugly case -- need to flush for control hazards when X busy, but other cases require stalling to take priority to prevent data loss (e.g. slow instruction fetch, valid insn in X, load in M --> giving flush priority would destroy insn in X)
                                   || hazard_if.mem_use_stall 
-                                  || hazard_if.fence_stall; // Data hazard -- stall until dependency clears (from E/M flush after writeback)
+                                  || hazard_if.fence_stall); // Data hazard -- stall until dependency clears (from E/M flush after writeback)
      // TODO: Exceptions
     assign hazard_if.ex_mem_stall = wait_for_dmem // Second clause ensures we finish memory op on interrupt condition
                                   || hazard_if.fence_stall

--- a/source_code/privs/priv_1_12/priv_1_12_block.sv
+++ b/source_code/privs/priv_1_12/priv_1_12_block.sv
@@ -126,5 +126,6 @@ module priv_1_12_block #(
     assign prv_pipe_if.prot_fault_i = prv_intern_if.pma_i_fault | prv_intern_if.pmp_i_fault;
     assign prv_pipe_if.prot_fault_l = prv_intern_if.pma_l_fault | prv_intern_if.pmp_l_fault;
     assign prv_pipe_if.prot_fault_s = prv_intern_if.pma_s_fault | prv_intern_if.pmp_s_fault;
+    assign prv_intern_if.ex_mem_stall = prv_pipe_if.ex_mem_stall;
 
 endmodule

--- a/source_code/privs/priv_1_12/priv_1_12_int_ex_handler.sv
+++ b/source_code/privs/priv_1_12/priv_1_12_int_ex_handler.sv
@@ -120,7 +120,7 @@ module priv_1_12_int_ex_handler (
                                     | (prv_intern_if.curr_mie.meie & prv_intern_if.curr_mip.meip)));
 
     // Register updates on Interrupts/Exceptions
-    assign prv_intern_if.inject_mcause = exception | interrupt_fired;
+    assign prv_intern_if.inject_mcause = (exception | interrupt_fired) && !prv_intern_if.ex_mem_stall;
     assign prv_intern_if.next_mcause.interrupt = ~exception;
     assign prv_intern_if.next_mcause.cause = exception ? ex_src : int_src;
 
@@ -147,7 +147,7 @@ module priv_1_12_int_ex_handler (
         else if (prv_intern_if.clear_timer_int_s) prv_intern_if.next_mip.stip = 1'b0;
     end
 
-    assign prv_intern_if.inject_mstatus = prv_intern_if.intr | prv_intern_if.mret;
+    assign prv_intern_if.inject_mstatus = (prv_intern_if.intr | prv_intern_if.mret) && !prv_intern_if.ex_mem_stall;
 
     always_comb begin
         prv_intern_if.next_mstatus = prv_intern_if.curr_mstatus;
@@ -172,7 +172,7 @@ module priv_1_12_int_ex_handler (
         end
     end
 
-    assign prv_intern_if.inject_mepc = exception | interrupt_fired;
+    assign prv_intern_if.inject_mepc = (exception | interrupt_fired) && !prv_intern_if.ex_mem_stall;
     assign prv_intern_if.next_mepc = prv_intern_if.epc;
 
     assign prv_intern_if.inject_mtval = (prv_intern_if.mal_l | prv_intern_if.fault_l


### PR DESCRIPTION
This PR fixes an issue where if the pipeline contains a jump instruction in execute and a load/store in memory when an interrupt is fired. In this case, the interrupt will fire, save the jump as the mepc, and insert the interrupt PC into the fetch stage. However, when the jump executes, the interrupt PC in the previous stage will be squashed giving incorrect behavior. 
![30122fcc-4131-4e1a-857f-a0dc58df2c85](https://github.com/user-attachments/assets/729d3fcb-4ccb-4c5d-bbf8-7beb7416401b)

After these changes, loads/stores will cause the interrupt to be stalled until the memory request completes.
<img width="592" alt="Screenshot 2025-03-07 at 6 15 47 PM" src="https://github.com/user-attachments/assets/ac88ee60-128a-4969-b153-29541a307070" />

The `int_during_ret` and `bus_fault` tests time out before and after this change, all other interrupt-exceptions tests continue to pass.

This won't cause any unintended effects to say tight loops which do many loads and stores since as soon as the first load/store completes, it will service the interrupt.