### PR TITLE
tb_core.cc: quality of life update

### DIFF
--- a/tb_core.cc
+++ b/tb_core.cc
@@ -37,7 +37,7 @@ uint32_t tohost_address = 0;
 uint64_t max_sim_time = BASE_SIM_TIME;
 bool tohost_break = false;
 bool virtual_test = false;
-bool require_trace = false;
+bool require_trace = true;
 
 /*
  *  Emulate memory-mapped CSRs


### PR DESCRIPTION
Got to the point in testing the Supervisor where it was annoying to constantly be changing things in tb_core.cc
Able to run embench tests on the Supervisor at a max sim time of 4294967295, with no trace generation. Runs riscv-tests, both physical and virtual as well for the Supervisor. As for stage3, the only support is for physical, which it passes as well.

Updated features
- Using '--help' accurately refers to --tohost-address now.

New features:
- **_Support for virtual tests._** Using '--virtual' alters the behavior of '--tohost-address' on processor writes. When the processor writes with the '--virtual' flag enabled, the processor doesn't stop and continues simulation. Perfect for virtual tests, and may have some use case if we want to use '--tohost-address' with any non-virtual tests. 
- **_Disabling trace generation._** Came across this when trying to run embench in virtual memory. It would take too long to simulation because of the trace, especially when those simulations are 84 million cycles...
- **_Specifying max simulation time._** I got fed up having to change the max simulation time manually whenever my programs would time out, then rebuild the core. Able to specify up to uint64_t max.
- **_'--help' refers to added runtime flags._**