### PR TITLE
Remove NONCACHE_START_ADDR from module parameters

### DIFF
--- a/example.yml
+++ b/example.yml
@@ -21,7 +21,7 @@ microarch_params:
   icache_size : 1024
   icache_block_size : 2
   icache_assoc : 1
-  noncache_start_addr : 32'hF000_0000
+  noncache_start_addr : 32'hA000_0000
   
   # Bus configurations
   bus_endianness      : "big"

--- a/example.yml
+++ b/example.yml
@@ -21,7 +21,7 @@ microarch_params:
   icache_size : 1024
   icache_block_size : 2
   icache_assoc : 1
-  noncache_start_addr : 32'hA000_0000
+  noncache_start_addr : 32'hF000_0000
   
   # Bus configurations
   bus_endianness      : "big"

--- a/source_code/caches/coherency_unit.sv
+++ b/source_code/caches/coherency_unit.sv
@@ -22,6 +22,7 @@
 *	Description:  Coherency unit for MESI Coherence
 */
 
+`include "component_selection_defines.vh"
 `include "generic_bus_if.vh"
 `include "cache_coherence_if.vh"
 `include "bus_ctrl_if.vh"
@@ -29,8 +30,7 @@
 module coherency_unit #(
     parameter ADDR_WIDTH = 32, // Address width for cache lines
     parameter BLOCK_SIZE = 2,
-    parameter CPUID = 0,
-    parameter NONCACHE_START_ADDR = 32'hF000_0000
+    parameter CPUID = 0
 ) (
     input logic CLK, nRST,
     bus_ctrl_if.tb bcif,            // Bus Controller Interface

--- a/source_code/caches/direct_mapped_tpf/direct_mapped_tpf_cache.sv
+++ b/source_code/caches/direct_mapped_tpf/direct_mapped_tpf_cache.sv
@@ -26,6 +26,7 @@
 *                     - Prefetch Length
 */
 
+`include "component_selection_defines.vh"
 `include "generic_bus_if.vh"
 
 module direct_mapped_tpf_cache (
@@ -47,7 +48,6 @@ module direct_mapped_tpf_cache (
     parameter CACHE_SIZE = 1024;  // In bytes, must be power of 2
     parameter BLOCK_SIZE = 2;  // must be power of 2
     parameter PREFETCH_LENGTH = 1;  // must be power of 2
-    parameter NONCACHE_START_ADDR = 32'h8000_0000;
 
     // local parameters
     localparam N_INDICES = CACHE_SIZE / (BLOCK_SIZE * WORD_SIZE / 8);

--- a/source_code/caches/l1/l1_cache.sv
+++ b/source_code/caches/l1/l1_cache.sv
@@ -26,6 +26,7 @@
 *	            - ASSOC | either 1 or 2
 */
 
+`include "component_selection_defines.vh"
 `include "generic_bus_if.vh"
 `include "cache_coherence_if.vh"
 
@@ -36,8 +37,7 @@
 module l1_cache #(
     parameter CACHE_SIZE          = 1024, // must be power of 2, in bytes, max 4k - 4 * 2^10
     parameter BLOCK_SIZE          = 2, // must be power of 2, max 8
-    parameter ASSOC               = 1, // dont set this to 0
-    parameter NONCACHE_START_ADDR = 32'hF000_0000 // sh/sb still have issues when uncached; not sure whats up with that still tbh
+    parameter ASSOC               = 1  // dont set this to 0
 )
 (
     input logic CLK, nRST,

--- a/source_code/caches/l1/l1_cache_noncoherent.sv
+++ b/source_code/caches/l1/l1_cache_noncoherent.sv
@@ -32,8 +32,7 @@ module l1_cache_noncoherent #(
     parameter CPUID,
     parameter CACHE_SIZE          = 1024, // must be power of 2, in bytes, max 4k - 4 * 2^10
     parameter BLOCK_SIZE          = 2, // must be power of 2, max 8
-    parameter ASSOC               = 1, // dont set this to 0
-    parameter NONCACHE_START_ADDR = 32'hF000_0000 // sh/sb still have issues when uncached; not sure whats up with that still tbh
+    parameter ASSOC               = 1  // dont set this to 0
 )
 (
     input logic CLK, nRST,

--- a/source_code/caches/separate_caches.sv
+++ b/source_code/caches/separate_caches.sv
@@ -72,8 +72,7 @@ module separate_caches (
             l1_cache #(
                 .CACHE_SIZE(DCACHE_SIZE),
                 .BLOCK_SIZE(DCACHE_BLOCK_SIZE),
-                .ASSOC(DCACHE_ASSOC),
-                .NONCACHE_START_ADDR(NONCACHE_START_ADDR)
+                .ASSOC(DCACHE_ASSOC)
             )
             dcache (
                 .CLK(CLK),
@@ -124,8 +123,7 @@ module separate_caches (
             l1_cache #(
                 .CACHE_SIZE(ICACHE_SIZE),
                 .BLOCK_SIZE(ICACHE_BLOCK_SIZE),
-                .ASSOC(ICACHE_ASSOC),
-                .NONCACHE_START_ADDR(NONCACHE_START_ADDR)
+                .ASSOC(ICACHE_ASSOC)
             )
             icache (
                 .CLK(CLK),

--- a/source_code/standard_core/bus_ctrl.sv
+++ b/source_code/standard_core/bus_ctrl.sv
@@ -22,12 +22,12 @@
 *	Description:  Bus controller for MESI cache coherence
 */
 
+`include "component_selection_defines.vh"
 `include "bus_ctrl_if.vh"
 
 module bus_ctrl #(
     parameter BLOCK_SIZE = 2,
-    parameter CPUS = 2,
-    parameter NONCACHE_START_ADDR = 32'hF000_0000
+    parameter CPUS = 2
 )(
     input logic CLK, nRST,
     bus_ctrl_if.cc ccif

--- a/source_code/standard_core/memory_controller.sv
+++ b/source_code/standard_core/memory_controller.sv
@@ -24,8 +24,8 @@
 *                 and data accesses
 */
 
-`include "generic_bus_if.vh"
 `include "component_selection_defines.vh"
+`include "generic_bus_if.vh"
 `include "bus_ctrl_if.vh"
 
 module memory_controller #(

--- a/source_code/tb/tb_cache_coh_wrapper.sv
+++ b/source_code/tb/tb_cache_coh_wrapper.sv
@@ -27,8 +27,7 @@ module cache_coh_wrapper(
     l1_cache #(
         .CACHE_SIZE(1024),
         .BLOCK_SIZE(2),
-        .ASSOC(1),
-        .NONCACHE_START_ADDR(32'hF000_0000)
+        .ASSOC(1)
     )
     dcache (
         .CLK(CLK),

--- a/source_code/tb/tb_cache_coherence_stress/cache_stress_wrapper.sv
+++ b/source_code/tb/tb_cache_coherence_stress/cache_stress_wrapper.sv
@@ -95,8 +95,7 @@ module cache_stress_wrapper (
     l1_cache #(
         .CACHE_SIZE(1024),
         .BLOCK_SIZE(2),
-        .ASSOC(1),
-        .NONCACHE_START_ADDR(32'hF000_0000)
+        .ASSOC(1)
     ) cache0 (
         .CLK(CLK),
         .nRST(nRST),
@@ -126,8 +125,7 @@ module cache_stress_wrapper (
     l1_cache #(
         .CACHE_SIZE(1024),
         .BLOCK_SIZE(2),
-        .ASSOC(1),
-        .NONCACHE_START_ADDR(32'hF000_0000)
+        .ASSOC(1)
     ) cache1 (
         .CLK(CLK),
         .nRST(nRST),

--- a/source_code/tb/tb_two_cache_coh_wrapper.sv
+++ b/source_code/tb/tb_two_cache_coh_wrapper.sv
@@ -18,8 +18,7 @@ module two_cache_coh_wrapper(
     l1_cache #(
         .CACHE_SIZE(1024),
         .BLOCK_SIZE(2),
-        .ASSOC(1),
-        .NONCACHE_START_ADDR(32'hF000_0000)
+        .ASSOC(1)
     ) cache0 (
         .CLK(CLK),
         .nRST(nRST),
@@ -47,8 +46,7 @@ module two_cache_coh_wrapper(
     l1_cache #(
         .CACHE_SIZE(1024),
         .BLOCK_SIZE(2),
-        .ASSOC(1),
-        .NONCACHE_START_ADDR(32'hF000_0000)
+        .ASSOC(1)
     ) cache1 (
         .CLK(CLK),
         .nRST(nRST),

--- a/verification/uvm/caches/tb_caches_top.sv
+++ b/verification/uvm/caches/tb_caches_top.sv
@@ -96,8 +96,7 @@ module tb_caches_top ();
   l1_cache #(
       .CACHE_SIZE(`L1_CACHE_SIZE),
       .BLOCK_SIZE(`L1_BLOCK_SIZE),
-      .ASSOC(`L1_ASSOC),
-      .NONCACHE_START_ADDR(`NONCACHE_START_ADDR)
+      .ASSOC(`L1_ASSOC)
   ) l1 (
       .CLK(d_cif.CLK),
       .nRST(d_cif.nRST),
@@ -115,8 +114,7 @@ module tb_caches_top ();
   // l2_cache #(
   //     .CACHE_SIZE(`L2_CACHE_SIZE),
   //     .BLOCK_SIZE(`L2_BLOCK_SIZE),
-  //     .ASSOC(`L2_ASSOC),
-  //     .NONCACHE_START_ADDR(`NONCACHE_START_ADDR)
+  //     .ASSOC(`L2_ASSOC)
   // ) l2 (
   //     .CLK(l2_cif.CLK),
   //     .nRST(l2_cif.nRST),
@@ -134,8 +132,7 @@ module tb_caches_top ();
   l1_cache #(
       .CACHE_SIZE(`L1_CACHE_SIZE),
       .BLOCK_SIZE(`L1_BLOCK_SIZE),
-      .ASSOC(`L1_ASSOC),
-      .NONCACHE_START_ADDR(`NONCACHE_START_ADDR)
+      .ASSOC(`L1_ASSOC)
   ) d_l1 (
       .CLK(d_cif.CLK),
       .nRST(d_cif.nRST),
@@ -153,8 +150,7 @@ module tb_caches_top ();
   l1_cache #(
       .CACHE_SIZE(`L1_CACHE_SIZE),
       .BLOCK_SIZE(`L1_BLOCK_SIZE),
-      .ASSOC(`L1_ASSOC),
-      .NONCACHE_START_ADDR(`NONCACHE_START_ADDR)
+      .ASSOC(`L1_ASSOC))
   ) i_l1 (
       .CLK(i_cif.CLK),
       .nRST(i_cif.nRST),
@@ -183,8 +179,7 @@ module tb_caches_top ();
   // l2_cache #(
   //     .CACHE_SIZE(`L2_CACHE_SIZE),
   //     .BLOCK_SIZE(`L2_BLOCK_SIZE),
-  //     .ASSOC(`L2_ASSOC),
-  //     .NONCACHE_START_ADDR(`NONCACHE_START_ADDR)
+  //     .ASSOC(`L2_ASSOC)
   // ) l2 (
   //     .CLK(l2_cif.CLK),
   //     .nRST(l2_cif.nRST),


### PR DESCRIPTION
Came across this when debugging Supervisor. Modules that define `NONCACHE_START_ADDR` as a parameter, but don't include `.NONCACHE_START_ADDR(NONCACHE_START_ADDR)` when setting up the module, will use the default `NONCACHE_START_ADDR` for that module, 0xF0000000. Big issue for AFT, where `NONCACHE_START_ADDR` starts at 0x80000000.

In this PR, I removed `NONCACHE_START_ADDR` from module parameter declarations and instead let those modules use the one defined by `component_selection_defines.vh`.

Below are screenshots showing correct (noncacheable-fix) and incorrect (stage3) waveforms. This is using a `NONCACHE_START_ADDR = 32'hA000_0000`.
Correct
![image](https://github.com/user-attachments/assets/1b152cb7-aa97-4814-9670-f25dd30fbfb2)

Incorrect
![image](https://github.com/user-attachments/assets/c759c4e7-946b-4d73-9cdd-541794f89675)

DM me on teams if you want the binary I used to test on your own. The signals shown are from the `TOP` module in gtkwave.