### PR TITLE
config_core.py: update file format to use regular isa string

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,6 +1,10 @@
 # ISA Configurations
 isa_params:  
   xlen : 32
+  pmp_minimum_granularity : "64K"
+  supervisor_enabled : "disabled"
+  address_translation_enabled : "disabled"
+  isa: "rv32izifencei_zicsr"
 
 # Microarchitectural Configurations
 microarch_params:
@@ -24,17 +28,5 @@ microarch_params:
   # Sparisty Optimizations
   sparce_enabled : "disabled"
 
-  # RV32C
-  rv32c_enabled : "disabled"
-  
   # Halt
   infinite_loop_halts : "true"
-
-  # base ISA 
-  base_isa: "RV32I"
-
-# RISC-MGMT Extension Configuration
-risc_mgmt_params:
-  standard_extensions:
-  nonstandard_extensions:
-

--- a/example.yml
+++ b/example.yml
@@ -4,6 +4,7 @@ isa_params:
   pmp_minimum_granularity : "64K"
   supervisor_enabled : "disabled"
   address_translation_enabled : "disabled"
+  isa: "rv32izifencei_zicsr"
 
 # Microarchitectural Configurations
 microarch_params:
@@ -34,18 +35,6 @@ microarch_params:
 
   # Sparisty Optimizations
   sparce_enabled : "disabled"
-
-  # RV32C
-  rv32c_enabled : "disabled"
   
   # Halt
   infinite_loop_halts : "true"
-
-  # base ISA 
-  base_isa: "RV32I"
-
-# RISC-MGMT Extension Configuration
-risc_mgmt_params:
-  standard_extensions:
-  nonstandard_extensions:
-

--- a/source_code/rv32c/rv32c_wrapper.sv
+++ b/source_code/rv32c/rv32c_wrapper.sv
@@ -6,14 +6,9 @@ module rv32c_wrapper (
     nRST,
     rv32c_if.rv32c rv32cif
 );
-
-    generate
-        /* verilator lint_off width */
-        case (RV32C_ENABLED)
-            /* verilator lint_on width */
-            "disabled": rv32c_disabled RV32C (.clk(CLK), .nrst(nRST), .rv32cif(rv32cif));
-            "enabled":  rv32c_enabled RV32C (.clk(CLK), .nrst(nRST), .rv32cif(rv32cif));
-        endcase
-    endgenerate
-
+    `ifdef RV32C_SUPPORTED
+        rv32c_enabled RV32C (.clk(CLK), .nrst(nRST), .rv32cif(rv32cif));
+    `else
+        rv32c_disabled RV32C (.clk(CLK), .nrst(nRST), .rv32cif(rv32cif));
+    `endif
 endmodule

--- a/source_code/rv32zc/rv32zc_wrapper.sv
+++ b/source_code/rv32zc/rv32zc_wrapper.sv
@@ -8,7 +8,7 @@ module rv32zc_wrapper(
     output logic [31:0] rv32zc_out
 );
 
-    `ifdef RV32ZC_SUPPORTED
+    `ifdef RV32ZICOND_SUPPORTED
         rv32zc_enabled RV32ZC(.*);
     `else
         rv32zc_disabled RV32ZC(.*);

--- a/source_code/standard_core/control_unit.sv
+++ b/source_code/standard_core/control_unit.sv
@@ -330,7 +330,7 @@ module control_unit (
     assign rv32b_claim = 1'b0;
     `endif
 
-    `ifdef RV32ZC_SUPPORTED
+    `ifdef RV32ZICOND_SUPPORTED
     rv32zc_decode RV32ZC_DECODE(
         .insn(cu_if.instr),
         .claim(rv32zc_claim),


### PR DESCRIPTION
This might break how nonstandard extensions used to be handled, but (to my knowledge) they aren't currently existing or working anyways. In the future, it should be pretty simple to extend the script with the same functionality with a nonstandard extension->opcode table that is used to generate `ADD_EXTENSION_WITH_OPCODE` calls