### PR TITLE
Adding HPM3 & HPM4 to Priv 1.13

### DIFF
--- a/run_riscv_tests.py
+++ b/run_riscv_tests.py
@@ -99,9 +99,10 @@ def get_hostaddress(fname):
 
 def run_test(fname, env):
     tohost_address = get_hostaddress(fname)
-    run_cmd = [verilator_binary, '--tohost-address', str(tohost_address), fname]
+    run_cmd = [verilator_binary, '--tohost-address', str(tohost_address), '--notrace']
     if env == 'v':
-        run_cmd = [verilator_binary, '--tohost-address', str(tohost_address), '--max-sim-time', '1000000', '--virtual', fname, '--notrace']
+        run_cmd.extend(['--max-sim-time', '1000000', '--virtual'])
+    run_cmd.append(fname)
     res = subprocess.run(run_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
 
     print(f'\t{fname}: ', end="")

--- a/source_code/include/priv_1_13_internal_if.vh
+++ b/source_code/include/priv_1_13_internal_if.vh
@@ -44,8 +44,7 @@ interface priv_1_13_internal_if;
     logic csr_write, csr_set, csr_clear, csr_read_only; // Is the CSR currently being modified?
     logic invalid_csr; // Bad CSR address
     logic inst_ret; // signal when an instruction is retired
-    logic hpm3_inc; // counter for icache misses
-    logic hpm4_inc; // counter for dcache misses
+    word_t hpm_inc; // increment counter for hpm values
     word_t new_csr_val, old_csr_val; // new and old CSR values (atomically swapped)
     logic valid_write; // valid write occurs with an r type instruction that does not have any pipeline stalls
 
@@ -103,7 +102,7 @@ interface priv_1_13_internal_if;
     logic pmp_s_fault, pmp_l_fault, pmp_i_fault; // PMP store fault, load fault, instruction fault
 
     modport csr (
-        input csr_addr, curr_privilege_level, csr_write, csr_set, csr_clear, csr_read_only, new_csr_val, inst_ret, hpm3_inc, hpm4_inc,
+        input csr_addr, curr_privilege_level, csr_write, csr_set, csr_clear, csr_read_only, new_csr_val, inst_ret, hpm_inc,
             valid_write, inject_mcause, inject_mepc, inject_mip, inject_mstatus, inject_mtval, inject_scause, inject_sepc, inject_stval,
             next_mcause, next_mepc, next_mie, next_mip, next_mstatus, next_mtval, next_scause, next_sepc, next_stval,
             isUMode, isSMode, isMMode,

--- a/source_code/include/priv_1_13_internal_if.vh
+++ b/source_code/include/priv_1_13_internal_if.vh
@@ -44,6 +44,8 @@ interface priv_1_13_internal_if;
     logic csr_write, csr_set, csr_clear, csr_read_only; // Is the CSR currently being modified?
     logic invalid_csr; // Bad CSR address
     logic inst_ret; // signal when an instruction is retired
+    logic hpm3_inc; // counter for icache misses
+    logic hpm4_inc; // counter for dcache misses
     word_t new_csr_val, old_csr_val; // new and old CSR values (atomically swapped)
     logic valid_write; // valid write occurs with an r type instruction that does not have any pipeline stalls
 
@@ -77,6 +79,7 @@ interface priv_1_13_internal_if;
     csr_reg_t curr_stval, next_stval;
     satp_t curr_satp;
     logic inject_mip, inject_mcause, inject_mepc, inject_mstatus, inject_mtval, inject_scause, inject_sepc, inject_stval;
+    logic isUMode, isSMode, isMMode;
 
     // Things from the pipe we care about
     word_t epc; // pc of the instruction prior to the exception
@@ -100,9 +103,10 @@ interface priv_1_13_internal_if;
     logic pmp_s_fault, pmp_l_fault, pmp_i_fault; // PMP store fault, load fault, instruction fault
 
     modport csr (
-        input csr_addr, curr_privilege_level, csr_write, csr_set, csr_clear, csr_read_only, new_csr_val, inst_ret, valid_write,
-            inject_mcause, inject_mepc, inject_mip, inject_mstatus, inject_mtval, inject_scause, inject_sepc, inject_stval,
+        input csr_addr, curr_privilege_level, csr_write, csr_set, csr_clear, csr_read_only, new_csr_val, inst_ret, hpm3_inc, hpm4_inc,
+            valid_write, inject_mcause, inject_mepc, inject_mip, inject_mstatus, inject_mtval, inject_scause, inject_sepc, inject_stval,
             next_mcause, next_mepc, next_mie, next_mip, next_mstatus, next_mtval, next_scause, next_sepc, next_stval,
+            isUMode, isSMode, isMMode,
         output old_csr_val, invalid_csr,
             curr_medeleg, curr_mideleg, curr_mcause, curr_mepc, curr_mie, curr_mip, curr_mstatus, curr_mtvec, curr_scause, curr_sepc, curr_stvec, curr_satp
     );
@@ -113,6 +117,7 @@ interface priv_1_13_internal_if;
             clear_ext_int_u, clear_ext_int_s, clear_ext_int_m, mal_insn, fault_insn_access, illegal_insn, breakpoint, fault_l, mal_l, fault_s, mal_s,
             env_u, env_s, env_m, fault_insn_page, fault_load_page, fault_store_page, curr_medeleg, curr_mideleg, curr_mcause, curr_mepc, curr_mie,
             curr_mip, curr_mstatus, curr_mtval, curr_scause, curr_sepc, curr_stval, mret, sret, pipe_clear, ex_rmgmt, ex_rmgmt_cause, epc, curr_privilege_level, ex_mem_stall,
+            isUMode, isSMode, isMMode,
         output inject_mcause, inject_mepc, inject_mip, inject_mstatus, inject_mtval, inject_scause, inject_sepc, inject_stval,
             next_mcause, next_mepc, next_mie, next_mip, next_mstatus, next_mtval, next_scause, next_sepc, next_stval, intr,
             intr_to_s
@@ -130,13 +135,13 @@ interface priv_1_13_internal_if;
     );
 
     modport pmp (
-        input iaddr, daddr, ren, wen, xen, curr_privilege_level, curr_mstatus,
+        input iaddr, daddr, ren, wen, xen, curr_privilege_level, curr_mstatus, isUMode, isSMode, isMMode,
         output pmp_s_fault, pmp_i_fault, pmp_l_fault
     );
 
     modport mode (
         input mret, sret, curr_mstatus, intr, intr_to_s,
-        output curr_privilege_level
+        output curr_privilege_level, isUMode, isSMode, isMMode
     );
 
 endinterface

--- a/source_code/privs/priv_1_13/priv_1_13_block.sv
+++ b/source_code/privs/priv_1_13/priv_1_13_block.sv
@@ -50,8 +50,8 @@ module priv_1_13_block #(
     priv_1_13_mode mode (.CLK(CLK), .nRST(nRST), .prv_intern_if(prv_intern_if));
 
     // Assign CSR values
-    assign prv_intern_if.hpm3_inc = prv_pipe_if.icache_miss;
-    assign prv_intern_if.hpm4_inc = prv_pipe_if.dcache_miss;
+    assign prv_intern_if.hpm_inc[3] = prv_pipe_if.icache_miss;
+    assign prv_intern_if.hpm_inc[4] = prv_pipe_if.dcache_miss;
     assign prv_intern_if.inst_ret = prv_pipe_if.wb_enable & prv_pipe_if.instr;
     assign prv_intern_if.csr_addr = prv_pipe_if.csr_addr;
     assign prv_intern_if.csr_write = prv_pipe_if.swap;

--- a/source_code/privs/priv_1_13/priv_1_13_mode.sv
+++ b/source_code/privs/priv_1_13/priv_1_13_mode.sv
@@ -58,5 +58,8 @@ module priv_1_13_mode (
     end
 
     assign prv_intern_if.curr_privilege_level = curr_priv_level;
+    assign prv_intern_if.isUMode = curr_priv_level == U_MODE;
+    assign prv_intern_if.isSMode = (curr_priv_level == S_MODE) & (SUPERVISOR_ENABLED == "enabled");  // supervisor enabled sanity check
+    assign prv_intern_if.isMMode = curr_priv_level == M_MODE;
 
 endmodule

--- a/source_code/privs/priv_1_13/priv_1_13_pmp.sv
+++ b/source_code/privs/priv_1_13/priv_1_13_pmp.sv
@@ -201,7 +201,7 @@ module priv_1_13_pmp (
       default: d_match_found = 1'b0;
     endcase
 
-    if (prv_intern_if.curr_privilege_level != M_MODE || (prv_intern_if.curr_mstatus.mprv && prv_intern_if.curr_mstatus.mpp != M_MODE)) begin  // Core is in an unprivileged state or needs privilege checks
+    if (!prv_intern_if.isMMode || (prv_intern_if.curr_mstatus.mprv && prv_intern_if.curr_mstatus.mpp != M_MODE)) begin  // Core is in an unprivileged state or needs privilege checks
       if (~d_match_found) begin
         d_prot_fault = 1'b1;
       end else begin
@@ -262,7 +262,7 @@ module priv_1_13_pmp (
       default: i_match_found = 1'b0;
     endcase
 
-    if (prv_intern_if.curr_privilege_level != M_MODE || (prv_intern_if.curr_mstatus.mprv && prv_intern_if.curr_mstatus.mpp != M_MODE)) begin  // Core is in an unprivileged state or needs privilege checks
+    if (!prv_intern_if.isMMode || (prv_intern_if.curr_mstatus.mprv && prv_intern_if.curr_mstatus.mpp != M_MODE)) begin  // Core is in an unprivileged state or needs privilege checks
       if (~i_match_found) begin
         i_prot_fault = 1'b1;
       end else begin


### PR DESCRIPTION
Forgot to add these into the Supervisor PR. Added the supporting tests to make this all work. One note, the u-mode & s-mode CSR tests only work when the PMP granularity is set to 4. Will close https://github.com/Purdue-SoCET/RISCVBusiness/issues/82.