### PR TITLE
Revise RISCVBusiness for AFT FPGA Build

### DIFF
--- a/riscv-tests-env.patch
+++ b/riscv-tests-env.patch
@@ -40,6 +40,7 @@ index 7bf35cf..52bb51a 100644
 +    li sp, 0x90000000;                                                                            \
 +
  #endif
+
 diff --git a/v/amo_emu.c b/v/amo_emu.c
 new file mode 100644
 index 0000000..c432389
@@ -294,7 +295,7 @@ index 0000000..c432389
 +    __builtin_unreachable();
 +}
 diff --git a/v/vm.c b/v/vm.c
-index 178d90b..50ec166 100644
+index 178d90b..3148bc6 100644
 --- a/v/vm.c
 +++ b/v/vm.c
 @@ -22,8 +22,6 @@ extern volatile uint64_t fromhost;
@@ -319,7 +320,7 @@ index 178d90b..50ec166 100644
 -    cputchar(*s++);
 +  size_t len = strlen(s);
 +  for (size_t i = 0; i < len; i++) {
-+    cputchar(*s++);  
++    cputchar(*s++);
 +  }
 +  cputchar('\n');
  }
@@ -342,3 +343,17 @@ index 178d90b..50ec166 100644
  
      terminate(n);
    }
+@@ -228,12 +231,7 @@ static void coherence_torture()
+   uint64_t random = ENTROPY;
+   while (1) {
+     uintptr_t paddr = DRAM_BASE + ((random % (2 * (MAX_TEST_PAGES + 1) * PGSIZE)) & -4);
+-#ifdef __riscv_atomic
+-    if (random & 1) // perform a no-op write
+-      asm volatile ("amoadd.w zero, zero, (%0)" :: "r"(paddr));
+-    else // perform a read
+-#endif
+-      asm volatile ("lw zero, (%0)" :: "r"(paddr));
++    asm volatile ("lw zero, (%0)" :: "r"(paddr));
+     random = lfsr63(random);
+   }
+ }

--- a/riscv-tests-isa.patch
+++ b/riscv-tests-isa.patch
@@ -11,6 +11,15 @@ index bf85e1f..1e68ca1 100644
  RISCV_OBJDUMP ?= $(RISCV_PREFIX)objdump --disassemble-all --disassemble-zeroes --section=.text --section=.text.startup --section=.text.init --section=.data
  RISCV_SIM ?= spike
  
+@@ -66,7 +66,7 @@ vpath %.S $(src_dir)
+ define compile_template
+ 
+ $$($(1)_p_tests): $(1)-p-%: $(1)/%.S
+-	$$(RISCV_GCC) $(2) $$(RISCV_GCC_OPTS) -I$(src_dir)/../env/p -I$(src_dir)/macros/scalar -T$(src_dir)/../env/p/link.ld $$< -o $$@
++	$$(RISCV_GCC) $(2) $$(RISCV_GCC_OPTS) -I$(src_dir)/../env/p -I$(src_dir)/macros/scalar -T$(src_dir)/../env/p/link.ld $$< $(src_dir)/../env/v/amo_emu.c -o $$@
+ $(1)_tests += $$($(1)_p_tests)
+ 
+ $$($(1)_v_tests): $(1)-v-%: $(1)/%.S
 diff --git a/isa/rv64si/dirty.S b/isa/rv64si/dirty.S
 index 15f3163..73c8adf 100644
 --- a/isa/rv64si/dirty.S

--- a/run_riscv_tests.py
+++ b/run_riscv_tests.py
@@ -101,7 +101,7 @@ def run_test(fname, env):
     tohost_address = get_hostaddress(fname)
     run_cmd = [verilator_binary, '--tohost-address', str(tohost_address), '--notrace']
     if env == 'v':
-        run_cmd.extend(['--max-sim-time', '1000000', '--virtual'])
+        run_cmd.extend(['--max-sim-time', '1000000'])
     run_cmd.append(fname)
     res = subprocess.run(run_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
 

--- a/source_code/caches/separate_caches.sv
+++ b/source_code/caches/separate_caches.sv
@@ -37,7 +37,7 @@ module separate_caches(
     generic_bus_if.generic_bus icache_proc_gen_bus_if,
     generic_bus_if.generic_bus dcache_proc_gen_bus_if,
     cache_control_if.caches control_if,
-    prv_pipeline_if.cache prv_pipe_if,
+    prv_pipeline_if prv_pipe_if,
     front_side_bus_if.cache dcache_bus_ctrl_if,
     front_side_bus_if.cache icache_bus_ctrl_if,
     output logic abort_bus,

--- a/source_code/include/bus_ctrl_if.vh
+++ b/source_code/include/bus_ctrl_if.vh
@@ -127,7 +127,7 @@ interface back_side_bus_if#(
             `MAP_FRONT_TO_BACK(dREN)
             `MAP_FRONT_TO_BACK(dWEN)
             `MAP_FRONT_TO_BACK(daddr)
-            `MAP_FRONT_TO_BACK(dstore)
+            assign dstore[i] = ccsnoopdone[i] ? snoop_dstore[i] : front_side[i].dstore;
             `MAP_FRONT_TO_BACK(dbyte_en)
             `MAP_FRONT_TO_BACK(ccwrite)
             `MAP_FRONT_TO_BACK(ccsnoophit)
@@ -142,19 +142,6 @@ interface back_side_bus_if#(
             `MAP_BACK_TO_FRONT(ccexclusive)
         end
     endgenerate
-
-    // HACK: dstore becomes multidriven here. memory_controller expects to drive dstore but
-    // this is also used when testbenching
-    `ifndef VERILATOR
-    `ifndef XCELIUM
-    always_comb begin
-        for(int i = 0; i < CPUS; i++) begin
-            if(ccsnoopdone[i]) dstore[i] = snoop_dstore[i];
-            else dstore[i] = driver_dstore[i];
-        end
-    end
-    `endif
-    `endif
 
     // modports
     modport cc(

--- a/source_code/include/bus_ctrl_if.vh
+++ b/source_code/include/bus_ctrl_if.vh
@@ -127,7 +127,7 @@ interface back_side_bus_if#(
             `MAP_FRONT_TO_BACK(dREN)
             `MAP_FRONT_TO_BACK(dWEN)
             `MAP_FRONT_TO_BACK(daddr)
-            assign dstore[i] = ccsnoopdone[i] ? snoop_dstore[i] : front_side[i].dstore;
+            `MAP_FRONT_TO_BACK(dstore)
             `MAP_FRONT_TO_BACK(dbyte_en)
             `MAP_FRONT_TO_BACK(ccwrite)
             `MAP_FRONT_TO_BACK(ccsnoophit)

--- a/source_code/include/prv_pipeline_if.vh
+++ b/source_code/include/prv_pipeline_if.vh
@@ -81,10 +81,10 @@ interface prv_pipeline_if();
 
   modport hazard (
     input priv_pc, insert_pc, intr, prot_fault_s, prot_fault_l, prot_fault_i,
+          fault_insn_page, fault_load_page, fault_store_page,
     output pipe_clear, mret, sret, epc, fault_insn, mal_insn,
             illegal_insn, fault_l, mal_l, fault_s, mal_s,
-            breakpoint, env, fault_insn_page, fault_load_page, fault_store_page,
-            wfi, badaddr, wb_enable, ex_rmgmt, ex_rmgmt_cause, ex_mem_stall
+            breakpoint, env, wfi, badaddr, wb_enable, ex_rmgmt, ex_rmgmt_cause, ex_mem_stall
   );
 
   modport pipe (
@@ -92,14 +92,23 @@ interface prv_pipeline_if();
     input  rdata, invalid_priv_isn, fault_insn_page, fault_load_page, fault_store_page, dtlb_miss, mstatus, curr_privilege_level
   );
 
+  modport cu (
+    input mstatus, curr_privilege_level
+  );
+
   modport fetch (
     input prot_fault_i, itlb_miss,
     output iren, iaddr, i_acc_width
   );
 
-  modport cache (
+  modport caches (
     input satp, mstatus, curr_privilege_level, fence_va, fence_asid, ex_mem_ren, ex_mem_wen,
     output fault_insn_page, fault_load_page, fault_store_page, itlb_miss, dtlb_miss, ipaddr, dpaddr
+  );
+
+  modport cache (
+    input satp, mstatus, curr_privilege_level, fence_va, fence_asid, ex_mem_ren, ex_mem_wen,
+          fault_insn_page, fault_load_page, fault_store_page, itlb_miss, dtlb_miss, ipaddr, dpaddr
   );
 
   modport priv_block (

--- a/source_code/pipelines/stage3/source/stage3_execute_stage.sv
+++ b/source_code/pipelines/stage3/source/stage3_execute_stage.sv
@@ -43,7 +43,7 @@ module stage3_execute_stage (
     //risc_mgmt_if.ts_execute rm_if,
     sparce_pipeline_if.pipe_execute sparce_if,
     rv32c_if.execute rv32cif,
-    prv_pipeline_if.pipe prv_pipe_if
+    prv_pipeline_if.cu prv_pipe_if
 );
     import rv32i_types_pkg::*;
     import pma_types_pkg::*;

--- a/source_code/standard_core/control_unit.sv
+++ b/source_code/standard_core/control_unit.sv
@@ -33,7 +33,7 @@
 module control_unit (
     control_unit_if.control_unit       cu_if,
     rv32i_reg_file_if.cu               rf_if,
-    prv_pipeline_if.pipe               prv_pipe_if,
+    prv_pipeline_if.cu                 prv_pipe_if,
     input logic                        [4:0] rmgmt_rsel_s_0,
     rmgmt_rsel_s_1,
     rmgmt_rsel_d,

--- a/source_code/standard_core/multicore_wrapper.sv
+++ b/source_code/standard_core/multicore_wrapper.sv
@@ -60,7 +60,7 @@ module multicore_wrapper #(
     logic [NUM_HARTS-1:0] [11:0] imm_I;
     logic [NUM_HARTS-1:0] [20:0] imm_UJ;
     logic [NUM_HARTS-1:0] [31:0] imm_U;
-    logic [NUM_HARTS-1:0] abort_bus;
+    logic [(2*NUM_HARTS)-1:0] abort_bus;
 
     assign bus_ctrl_if.ccabort = abort_bus;
 
@@ -88,7 +88,7 @@ module multicore_wrapper #(
                 .interrupt_if(interrupt_if),
                 .dcache_bus_ctrl_if(front_side_bus[HART_ID*2 + 1]),
                 .icache_bus_ctrl_if(front_side_bus[HART_ID*2]),
-                .abort_bus(abort_bus[HART_ID])
+                .abort_bus(abort_bus[HART_ID*2])
             );
 
             // always_comb begin

--- a/source_code/standard_core/multicore_wrapper.sv
+++ b/source_code/standard_core/multicore_wrapper.sv
@@ -88,7 +88,7 @@ module multicore_wrapper #(
                 .interrupt_if(interrupt_if),
                 .dcache_bus_ctrl_if(front_side_bus[HART_ID*2 + 1]),
                 .icache_bus_ctrl_if(front_side_bus[HART_ID*2]),
-                .abort_bus(abort_bus)
+                .abort_bus(abort_bus[HART_ID])
             );
 
             // always_comb begin

--- a/tb_core.cc
+++ b/tb_core.cc
@@ -36,7 +36,7 @@ bool use_tohost = false;
 uint32_t tohost_address = 0;
 uint64_t max_sim_time = BASE_SIM_TIME;
 bool tohost_break = false;
-bool virtual_test = false;
+bool debug_test = false;
 bool require_trace = true;
 
 /*
@@ -175,7 +175,7 @@ public:
         }
 
         if(use_tohost && addr == tohost_address) {
-            if (virtual_test)
+            if (debug_test)
                 std::cout << static_cast<char>(value);
             else
                 tohost_break = true;
@@ -268,11 +268,11 @@ void reset(Vtop_core& dut, VerilatedFstC& trace) {
 }
 
 void print_help() {
-    std::cout << "Usage: ./Vtop_core [--tohost-address <unsigned int> --max-sim-time <unsigned long> --virtual --notrace] <filename>" << std::endl;
+    std::cout << "Usage: ./Vtop_core [--tohost-address <unsigned int> --max-sim-time <unsigned long> --debug --notrace] <filename>" << std::endl;
     std::cout << "\t--help   : Print this" << std::endl;
-    std::cout << "\t--tohost-address <address>: address for tohost checking functionality. A write to this address will end the program if --virtual is not set." << std::endl;
+    std::cout << "\t--tohost-address <address>: address for tohost checking functionality. A write to this address will end the program if --debug is not set." << std::endl;
     std::cout << "\t--max-sim-time <sim-time> : Maximum time to run simulation. Defaults to 100,000." << std::endl;
-    std::cout << "\t--virtual: Indicate virtualized address space will be run. Changes tohost-address functionality" << std::endl;
+    std::cout << "\t--debug  : Allows debug strings to print from cores. Changes tohost-address functionality" << std::endl;
     std::cout << "\t--notrace: Indicate to not generate a waveform file. Speeds up simulation incredibly." << std::endl;
     std::cout << "\tfilename : An executable .bin file to run" << std::endl;
 }
@@ -316,8 +316,8 @@ int main(int argc, char **argv) {
         } else if(strcmp(argv[i], "--help") == 0) {
             print_help();
             return 1;
-        } else if(strcmp(argv[i], "--virtual") == 0) {
-            virtual_test = true;
+        } else if(strcmp(argv[i], "--debug") == 0) {
+            debug_test = true;
         } else if(strcmp(argv[i], "--notrace") == 0) {
             require_trace = false;
         } else {


### PR DESCRIPTION
Includes the necessary RISCVBusiness changes to make the new split bus interfaces synthesis on the FPGA.

To test the changes,
1. From the root of RVB, run `cd riscv-tests/isa`. Run `make clean` and `rm -rf *.bin`.
2. From `riscv-tests/isa`, run `cd ..`. Run `make clean`.
3. From `riscv-tests`, run `cd ..`. Run `./setup-riscv-tests.sh`.
4. In `example.yml`, set `supervisor` to `"enabled"`, `address_translation` to `"enabled"`, `isa` to `"rv32imaczifencei_zicsr"`, and `num_harts` to `2`.
5. Run `make clean` and `ccache -C`. Then run `make verilate`
6. Run the following commands:
- `python3 run_riscv_tests.py --environment p --isa i`
- `python3 run_riscv_tests.py --environment p --isa m`
- `python3 run_riscv_tests.py --environment p --isa a`
- `python3 run_riscv_tests.py --environment v --isa i`
- `python3 run_riscv_tests.py --environment v --isa m`
Everything should pass.