### PR TITLE
Fix CPU Tracker

### DIFF
--- a/source_code/standard_core/multicore_wrapper.sv
+++ b/source_code/standard_core/multicore_wrapper.sv
@@ -52,7 +52,7 @@ module multicore_wrapper #(
     logic [NUM_HARTS-1:0] [4:0] rs2;
     logic [NUM_HARTS-1:0] [4:0] rd;
     logic [NUM_HARTS-1:0] instr_30;
-    rv32i_types_pkg::opcode_t opcode [NUM_HARTS-1:0];
+    rv32i_types_pkg::opcode_t [NUM_HARTS-1:0] opcode;
     logic [NUM_HARTS-1:0] [12:0] imm_SB;
     logic [NUM_HARTS-1:0] [11:0] imm_S;
     logic [NUM_HARTS-1:0] [11:0] imm_I;
@@ -89,25 +89,25 @@ module multicore_wrapper #(
                 .abort_bus(abort_bus[HART_ID*2])
             );
 
-            // always_comb begin
-            //     wb_stall[HART_ID] = hart.pipeline.mem_stage_i.wb_stall || pipeline_halts[HART_ID];
-            //     instr[HART_ID] = hart.pipeline.mem_pipe_if.ex_mem_reg.instr;
-            //     pc[HART_ID] = hart.pipeline.mem_pipe_if.ex_mem_reg.pc;
-            //     funct3[HART_ID] = hart.pipeline.mem_stage_i.funct3;
-            //     funct12[HART_ID] = hart.pipeline.mem_stage_i.funct12;
-            //     rs1[HART_ID] = hart.pipeline.mem_pipe_if.ex_mem_reg.instr[19:15];
-            //     rs2[HART_ID] = hart.pipeline.mem_pipe_if.ex_mem_reg.instr[24:20];
-            //     rd[HART_ID] = hart.pipeline.mem_pipe_if.ex_mem_reg.rd_m;
-            //     instr_30[HART_ID] = hart.pipeline.mem_stage_i.instr_30;
-            //     opcode[HART_ID] = hart.pipeline.mem_pipe_if.ex_mem_reg.tracker_signals.opcode;
-            //     imm_SB[HART_ID] = hart.pipeline.mem_pipe_if.ex_mem_reg.tracker_signals.imm_SB;
-            //     imm_S[HART_ID] = hart.pipeline.mem_pipe_if.ex_mem_reg.tracker_signals.imm_S;
-            //     imm_I[HART_ID] = hart.pipeline.mem_pipe_if.ex_mem_reg.tracker_signals.imm_I;
-            //     imm_UJ[HART_ID] = hart.pipeline.mem_pipe_if.ex_mem_reg.tracker_signals.imm_UJ;
-            //     imm_U[HART_ID] = hart.pipeline.mem_pipe_if.ex_mem_reg.tracker_signals.imm_U;
-            // end
+            always_comb begin
+                wb_stall[HART_ID] = hart.pipeline.mem_stage_i.wb_stall || pipeline_halts[HART_ID];
+                instr[HART_ID] = hart.pipeline.mem_pipe_if.ex_mem_reg.instr;
+                pc[HART_ID] = hart.pipeline.mem_pipe_if.ex_mem_reg.pc;
+                funct3[HART_ID] = hart.pipeline.mem_stage_i.funct3;
+                funct12[HART_ID] = hart.pipeline.mem_stage_i.funct12;
+                rs1[HART_ID] = hart.pipeline.mem_pipe_if.ex_mem_reg.instr[19:15];
+                rs2[HART_ID] = hart.pipeline.mem_pipe_if.ex_mem_reg.instr[24:20];
+                rd[HART_ID] = hart.pipeline.mem_pipe_if.ex_mem_reg.rd_m;
+                instr_30[HART_ID] = hart.pipeline.mem_stage_i.instr_30;
+                opcode[HART_ID] = hart.pipeline.mem_pipe_if.ex_mem_reg.tracker_signals.opcode;
+                imm_SB[HART_ID] = hart.pipeline.mem_pipe_if.ex_mem_reg.tracker_signals.imm_SB;
+                imm_S[HART_ID] = hart.pipeline.mem_pipe_if.ex_mem_reg.tracker_signals.imm_S;
+                imm_I[HART_ID] = hart.pipeline.mem_pipe_if.ex_mem_reg.tracker_signals.imm_I;
+                imm_UJ[HART_ID] = hart.pipeline.mem_pipe_if.ex_mem_reg.tracker_signals.imm_UJ;
+                imm_U[HART_ID] = hart.pipeline.mem_pipe_if.ex_mem_reg.tracker_signals.imm_U;
+            end
 
-            // assign x28s[HART_ID] = hart.pipeline.execute_stage_i.g_rfile_select.rf.registers[28] == 32'b1;
+            assign x28s[HART_ID] = hart.pipeline.execute_stage_i.g_rfile_select.rf.registers[28] == 32'b1;
         end
     endgenerate
 

--- a/source_code/trackers/cpu_tracker.sv
+++ b/source_code/trackers/cpu_tracker.sv
@@ -33,7 +33,7 @@ module cpu_tracker #(
     input logic [NUM_HARTS-1:0] instr_30,
     input rv32i_types_pkg::word_t [NUM_HARTS-1:0] instr,
     input rv32i_types_pkg::word_t [NUM_HARTS-1:0] pc,
-    input rv32i_types_pkg::opcode_t opcode [NUM_HARTS-1:0],
+    input rv32i_types_pkg::opcode_t [NUM_HARTS-1:0] opcode,
     input logic [NUM_HARTS-1:0] [2:0] funct3,
     input logic [NUM_HARTS-1:0] [11:0] funct12,
     input logic [NUM_HARTS-1:0] [4:0] rs1,
@@ -50,12 +50,12 @@ module cpu_tracker #(
     import rv32m_pkg::*;
 
     integer fptr;
-    string instr_mnemonic [];
-    string src1 [];
-    string src2 [];
-    string dest [];
-    string operands [];
-    string csr [];
+    string instr_mnemonic [NUM_HARTS];
+    string src1 [NUM_HARTS];
+    string src2 [NUM_HARTS];
+    string dest [NUM_HARTS];
+    string operands [NUM_HARTS];
+    string csr [NUM_HARTS];
     string temp_str;
     string output_str;
     logic [NUM_HARTS-1:0] [63:0] pc64;

--- a/tb_core.cc
+++ b/tb_core.cc
@@ -393,8 +393,10 @@ int main(int argc, char **argv) {
         std::cout << "Test TIMED OUT" << std::endl;
     } else if(use_tohost && memory.read(tohost_address) == 1 || !use_tohost && dut.top_core->get_x28() == 1) {
         std::cout << "Test PASSED" << std::endl;
-    } else {
+    } else if(use_tohost) {
         std::cout << "Test FAILED: Test " << memory.read(tohost_address) << std::endl;
+    } else {
+        std::cout << "Test FAILED: Test " << dut.top_core->get_x28() << std::endl;
     }
 
     auto tend = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
Fixes CPU tracker not printing into the trace.log.

This required a fix for the variable length arrays declared `string myString []` without a corresponding `new` call. I just made them fixed-length arrays of size `NUM_HARTS` and the mnemonics print as expected.