### PR TITLE
l1_cache: separate tag writes from data writes

### DIFF
--- a/source_code/tb/tb_cache_coherence_stress/cache_coherence_stress.core
+++ b/source_code/tb/tb_cache_coherence_stress/cache_coherence_stress.core
@@ -37,6 +37,8 @@ targets:
                     - --trace-fst
                     - --trace-structs
                     - -Wno-WIDTH
+                    - -Wno-CASEINCOMPLETE
+                    - -Wno-SYMRSVDWORD
                     - --timing
                     - --compiler clang
                     - -CFLAGS -std=c++20


### PR DESCRIPTION
Previously, the select lines needed to be the same if we were writing to the sram. Now, the tag sram can freely do lookups and is overridden with the cpu sram select in cases where we allocate or free a line. During hits, we don't update the tag sram at all anymore. In these cases, we have control of the bus anyways so there is no possibility of another snoop request to interrupt the write. This handles an edge case where a false snoop response could be sent causing lines to enter the E state when they should've been S.