### PR TITLE
Build to the work root the test scripts expect (BUILD, TEST)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,26 +24,26 @@ config:
 	@python3 scripts/config_core.py example.yml
 
 verilate: config
-	@fusesoc --cores-root . run --setup --build --build-root rvb_out --target sim --tool verilator socet:riscv:RISCVBusiness --make_options='-j'
+	@fusesoc --cores-root . run --setup --build --work-root rvb_out/sim-verilator --target sim --tool verilator socet:riscv:RISCVBusiness --make_options='-j'
 	@echo "------------------------------------------------------------------"
 	@echo "Build finished, you can run with 'fusesoc run', or by navigating"
 	@echo "to the build directory created by FuseSoC and using the Makefile there."
 	@echo "------------------------------------------------------------------"
 
 no_mem: config
-	@fusesoc --cores-root . run --setup --build --build-root rvb_out --target no_mc --tool verilator socet:riscv:RISCVBusiness --make_options='-j'
+	@fusesoc --cores-root . run --setup --build --work-root rvb_out/no_mc-verilator --target no_mc --tool verilator socet:riscv:RISCVBusiness --make_options='-j'
 	@echo "------------------------------------------------------------------"
 	@echo "Build finished, you can run with 'fusesoc run', or by navigating"
 	@echo "to the build directory created by FuseSoC and using the Makefile there."
 	@echo "------------------------------------------------------------------"
 
 xcelium: config
-	@fusesoc --cores-root . run --setup --build --build-root rvb_out --target sim --tool xcelium socet:riscv:RISCVBusiness
+	@fusesoc --cores-root . run --setup --build --work-root rvb_out/sim-xcelium --target sim --tool xcelium socet:riscv:RISCVBusiness
 	@echo "Build finished, you can run with 'fusesoc run', or by navigating"
 	@echo "to the build directory created by FuseSoC and using the Makefile there."
 
 lint: config
-	@fusesoc --cores-root . run --setup --build --build-root rvb_out --target lint --tool verilator socet:riscv:RISCVBusiness
+	@fusesoc --cores-root . run --setup --build --work-root rvb_out/lint-verilator --target lint --tool verilator socet:riscv:RISCVBusiness
 	@echo "Lint finished, no errors found"
 
 clean:


### PR DESCRIPTION
PR #151 removed the VLNV segment from the simulator path in run_riscv_tests.py, run_tests_verilator.py, run.sh, and README.md, changing it to ./rvb_out/sim-verilator/Vtop_core. Nothing changed about how fusesoc is invoked, so the build kept landing in ./rvb_out/socet_riscv_RISCVBusiness_0.1.1/sim-verilator/ and every regression run since has died immediately with a FileNotFound error.

This went unnoticed because Purdue-SoCET/RISC-V-CI did not propagate exit codes (also fixed in that repo). 

--build-root appends the VLNV by design, on every fusesoc from the pinned 2.0 through 2.4.5, so bumping fusesoc does not flatten the path. --work-root sets the output directory verbatim. Switching all four build targets to --work-root makes the layout match the paths master already documents, rather than reverting #151.

The fix allows all tests to pass.